### PR TITLE
Add additional tests

### DIFF
--- a/__snapshots__/index.test.ts.snap
+++ b/__snapshots__/index.test.ts.snap
@@ -1,6 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Sort JSON should sort unsorted JSON 1`] = `
+exports[`Sort JSON should sort a JSON object with unconventional keys 1`] = `
+"{
+  \\"\\": null,
+  \\"\\\\u0000\\": null,
+  \\"\\\\b\\": null,
+  \\"\\\\t\\": null,
+  \\"\\\\n\\": null,
+  \\"\\\\f\\": null,
+  \\"\\\\r\\": null,
+  \\" \\": null,
+  \\"\\\\\\"\\": null,
+  \\"'\\": null,
+  \\"-10\\": null,
+  \\"-10.1e10\\": null,
+  \\"/\\": null,
+  \\"0X10\\": null,
+  \\"0x10\\": null,
+  \\"10.101\\": null,
+  \\"10.1e10\\": null,
+  \\"1E10\\": null,
+  \\"1e10\\": null,
+  \\"[\\": null,
+  \\"[1,2,3]\\": null,
+  \\"[]\\": null,
+  \\"\\\\\\\\\\": null,
+  \\"false\\": null,
+  \\"null\\": null,
+  \\"true\\": null,
+  \\"{\\": null,
+  \\"{}\\": null,
+  \\"￿\\": null
+}
+"
+`;
+
+exports[`Sort JSON should sort an unsorted JSON object 1`] = `
 "{
   \\"0\\": \\"0\\",
   \\"a\\": \\"a\\",
@@ -10,12 +45,47 @@ exports[`Sort JSON should sort unsorted JSON 1`] = `
 "
 `;
 
-exports[`Sort JSON should validate sorted JSON 1`] = `
+exports[`Sort JSON should validate a sorted JSON object 1`] = `
 "{
   \\"0\\": \\"0\\",
   \\"a\\": \\"a\\",
   \\"b\\": \\"b\\",
   \\"c\\": \\"c\\"
+}
+"
+`;
+
+exports[`Sort JSON should validate a sorted JSON object with unconventional keys 1`] = `
+"{
+  \\"\\": null,
+  \\"\\\\u0000\\": null,
+  \\"\\\\b\\": null,
+  \\"\\\\t\\": null,
+  \\"\\\\n\\": null,
+  \\"\\\\f\\": null,
+  \\"\\\\r\\": null,
+  \\" \\": null,
+  \\"\\\\\\"\\": null,
+  \\"'\\": null,
+  \\"-10\\": null,
+  \\"-10.1e10\\": null,
+  \\"/\\": null,
+  \\"0X10\\": null,
+  \\"0x10\\": null,
+  \\"10.101\\": null,
+  \\"10.1e10\\": null,
+  \\"1E10\\": null,
+  \\"1e10\\": null,
+  \\"[\\": null,
+  \\"[1,2,3]\\": null,
+  \\"[]\\": null,
+  \\"\\\\\\\\\\": null,
+  \\"false\\": null,
+  \\"null\\": null,
+  \\"true\\": null,
+  \\"{\\": null,
+  \\"{}\\": null,
+  \\"￿\\": null
 }
 "
 `;

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,8 +1,81 @@
 import { format } from 'prettier';
 import * as SortJsonPlugin from '.';
 
+const validNonObjectJsonExamples = [
+  '{}',
+];
+
+const unconventionalKeys = [
+  '',
+  `"`,
+  '\'',
+  '0x10',
+  '0X10',
+  'true',
+  'false',
+  'null',
+  '-10',
+  '10.101',
+  '1e10',
+  '10.1e10',
+  '-10.1e10',
+  '1E10',
+  '{}',
+  '[]',
+  '[1,2,3]',
+  '[',
+  '{',
+  // eslint-disable-next-line no-useless-escape
+  '\"',
+  // eslint-disable-next-line no-useless-escape
+  '\/',
+  '\\',
+  '\b',
+  '\f',
+  '\n',
+  '\r',
+  '\t',
+  '\u0000',
+  '\uffff',
+  '\uFFFF',
+  '\u0020',
+];
+
 describe('Sort JSON', () => {
-  it('should validate sorted JSON', () => {
+  it('should return an empty string unchanged', () => {
+    const output = format('', {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+    });
+
+    expect(output).toBe('');
+  });
+
+  it('should return an empty string when given a newline', () => {
+    const output = format('\n', {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+    });
+
+    expect(output).toBe('');
+  });
+
+  for (const validNonObjectJson of validNonObjectJsonExamples) {
+    it(`should return '${validNonObjectJson}' unchanged`, () => {
+      const validNonObjectJsonWithNewline = `${validNonObjectJson}\n`;
+      const output = format(validNonObjectJsonWithNewline, {
+        filepath: 'foo.json',
+        parser: 'json',
+        plugins: [SortJsonPlugin],
+      });
+
+      expect(output).toBe(validNonObjectJsonWithNewline);
+    });
+  }
+
+  it('should validate a sorted JSON object', () => {
     const fixture = {
       0: '0',
       a: 'a',
@@ -20,13 +93,54 @@ describe('Sort JSON', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should sort unsorted JSON', () => {
+  it('should sort an unsorted JSON object', () => {
     const fixture = {
       0: '0',
       b: 'b',
       a: 'a',
       c: 'c',
     };
+
+    const input = JSON.stringify(fixture, null, 2);
+    const output = format(input, {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+    });
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should validate a sorted JSON object with unconventional keys', () => {
+    const fixture = unconventionalKeys
+      .sort()
+      .reduce(
+        (agg, key) => {
+          return { ...agg, [key]: null };
+        },
+        {}
+      );
+
+    const input = JSON.stringify(fixture, null, 2);
+    const output = format(input, {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+    });
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should sort a JSON object with unconventional keys', () => {
+    const fixture = unconventionalKeys
+      .sort()
+      .reverse()
+      .reduce(
+        (agg, key) => {
+          return { ...agg, [key]: null };
+        },
+        {}
+      );
 
     const input = JSON.stringify(fixture, null, 2);
     const output = format(input, {


### PR DESCRIPTION
A few non-Object JSON test cases have been tested to ensure they aren't modified unintentionally. The regular JSON Prettier parser does already make some changes such as adding a trailing newline, so those are reflected in some test cases.

A test has been included that has every weird key name I could think of. It is tested both sorted and unsorted.