### PR TITLE
Handle invalid JSON

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -62,6 +62,16 @@ describe('Sort JSON', () => {
     expect(output).toBe('');
   });
 
+  it('should throw Syntax Error in parser for invalid JSON', () => {
+    expect(() => {
+      format('{', {
+        filepath: 'foo.json',
+        parser: 'json',
+        plugins: [SortJsonPlugin],
+      });
+    }).toThrow(/^Unexpected token \(1:2\)/u);
+  });
+
   for (const validNonObjectJson of validNonObjectJsonExamples) {
     it(`should return '${validNonObjectJson}' unchanged`, () => {
       const validNonObjectJsonWithNewline = `${validNonObjectJson}\n`;

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,13 @@ export const parsers = {
         preprocessedText = babelParsers.json.preprocess(text, options);
       }
 
-      const json = JSON.parse(preprocessedText);
+      let json;
+      try {
+        json = JSON.parse(preprocessedText);
+      } catch (_) {
+        // skip invalid JSON; this is best handled by the regular JSON parser
+        return text;
+      }
 
       const sortedJson: Record<string, any> = {};
       for (const key of Object.keys(json).sort()) {


### PR DESCRIPTION
If the preprocessor encounters invalid JSON, it will return the text unchanged. The normal JSON parser is better suited to reporting problems with JSON parsing.