### PR TITLE
Skip sorting of non-Object values

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -1,8 +1,20 @@
 import { format } from 'prettier';
 import * as SortJsonPlugin from '.';
 
-const validNonObjectJsonExamples = [
+const validJsonExamples = [
+  'null',
+  'true',
+  'false',
+  '10',
+  '-10',
+  '10.101',
+  '1e10',
+  '10.1e10',
+  '-10.1e10',
+  '""',
   '{}',
+  '[]',
+  '[1, 2, 3]',
 ];
 
 const unconventionalKeys = [
@@ -72,16 +84,16 @@ describe('Sort JSON', () => {
     }).toThrow(/^Unexpected token \(1:2\)/u);
   });
 
-  for (const validNonObjectJson of validNonObjectJsonExamples) {
-    it(`should return '${validNonObjectJson}' unchanged`, () => {
-      const validNonObjectJsonWithNewline = `${validNonObjectJson}\n`;
-      const output = format(validNonObjectJsonWithNewline, {
+  for (const validJson of validJsonExamples) {
+    it(`should return '${validJson}' unchanged`, () => {
+      const validJsonWithNewline = `${validJson}\n`;
+      const output = format(validJsonWithNewline, {
         filepath: 'foo.json',
         parser: 'json',
         plugins: [SortJsonPlugin],
       });
 
-      expect(output).toBe(validNonObjectJsonWithNewline);
+      expect(output).toBe(validJsonWithNewline);
     });
   }
 

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,11 @@ export const parsers = {
         return text;
       }
 
+      // Only objects are intended to be sorted by this plugin
+      if (json === null || typeof json !== 'object' || Array.isArray(json)) {
+        return text;
+      }
+
       const sortedJson: Record<string, any> = {};
       for (const key of Object.keys(json).sort()) {
         sortedJson[key] = json[key];


### PR DESCRIPTION
Valid JSON values that are not Objects are now skipped. This includes Arrays and `null`, both of which are of type "object".