### PR TITLE
Add `prepublishOnly` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "tsc --project .",
+    "prepublishOnly": "yarn build",
     "test": "jest",
     "lint": "eslint . --ext .ts,.js"
   },


### PR DESCRIPTION
A `prepublishOnly` script has been added to ensure that we never forget to run `yarn build` before publishing.