### PR TITLE
Fix package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "prettier-plugin-sorted-json",
+  "name": "prettier-plugin-sort-json",
   "version": "0.0.1",
   "description": "Prettier plugin to sort JSON files alphanumerically by key",
   "main": "index.js",


### PR DESCRIPTION
The package was accidentally named `prettier-plugin-sorted-json` instead of `prettier-plugin-sort-json`.