### PR TITLE
Trigger test action upon pull request event

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: master
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `test` workflow is now triggered upon the `pull_request` event. The workflow is also triggered upon the `push` event still, but only on the `main` branch. Triggering the workflow upon `push` for feature branches would result in it running twice when a PR was open.