### PR TITLE
Fix main branch name in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 on:
   pull_request:
   push:
-    branches: master
+    branches: main
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The main branch name referenced in the `test` GitHub Action workflow was named incorrectly. It now correctly references `main`, the main branch.