### PR TITLE
Fix manifest `repository` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.1",
   "description": "Prettier plugin to sort JSON files alphanumerically by key",
   "main": "index.js",
-  "repository": "https://github.com/Gudahtt/prettier-plugin-sorted-json",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gudahtt/prettier-plugin-sort-json.git"
+  },
   "author": "Mark Stacey <markjstacey@gmail.com>",
   "files": [
     "index.js",


### PR DESCRIPTION
The `repository` property in the manifest referenced the wrong repository name. The URL has been fixed. The entry has also been updated to follow the [npm documentation's advice](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository) and declare a type explicitly.

Fixes #16