### PR TITLE
Remove unused `@types/babel` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "@babel/types": "^7.11.5",
     "@types/prettier": "^2.0.0",
     "prettier": "^2.0.0"
   }


### PR DESCRIPTION
This dependency seems to be unnecessary. I don't recall why I added it.