### PR TITLE
Move `prettier` to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,15 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-node": "^11.1.0",
+    "prettier": "^2.2.1",
     "jest": "^26.4.2",
     "ts-jest": "^26.3.0",
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "@types/prettier": "^2.2.0",
+    "@types/prettier": "^2.2.0"
+  },
+  "peerDependencies": {
     "prettier": "^2.2.1"
   }
 }


### PR DESCRIPTION
`prettier` is now listed among the `devDependencies` and the `peerDependencies`.