### PR TITLE
Add option to sort JSON recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ yarn add --dev prettier-plugin-sort-json
 
 This plugin adds a JSON preprocessor that will sort JSON files containing a JSON object alphanumerically by key. JSON files containing Arrays or other non-Object values are skipped.
 
-Currently we only perform a shallow sort. Nested objects are not sorted.
-
 Object entries are sorted by key using [`Array.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort), according to each character's Unicode code point value.
 
 ## Examples
@@ -59,3 +57,13 @@ After:
     "z": null
 }
 ```
+
+## Configuration
+
+### JSON Recursive Sort
+
+Sort JSON objects recursively, including all nested objects.
+
+| Default | CLI Override            | API Override                |
+| ------- | ----------------------- | --------------------------- |
+| `false` | `--json-recursive-sort` | `jsonRecursiveSort: <bool>` |

--- a/__snapshots__/index.test.ts.snap
+++ b/__snapshots__/index.test.ts.snap
@@ -42,7 +42,96 @@ exports[`Sort JSON should sort an unsorted JSON object 1`] = `
   \\"b\\": null,
   \\"exampleNestedObject\\": {
     \\"z\\": null,
+    \\"exampleArray\\": [\\"z\\", \\"b\\", \\"a\\"],
+    \\"examplePrimitive\\": 1,
     \\"a\\": null
+  },
+  \\"z\\": null
+}
+"
+`;
+
+exports[`Sort JSON should sort an unsorted JSON object recursively 1`] = `
+"{
+  \\"0\\": null,
+  \\"a\\": null,
+  \\"b\\": null,
+  \\"exampleNestedObject\\": {
+    \\"a\\": null,
+    \\"exampleArray\\": [\\"z\\", \\"b\\", \\"a\\"],
+    \\"examplePrimitive\\": 1,
+    \\"z\\": null
+  },
+  \\"z\\": null
+}
+"
+`;
+
+exports[`Sort JSON should sort an unsorted JSON object within an array recursively 1`] = `
+"[
+  1,
+  4,
+  {
+    \\"0\\": null,
+    \\"a\\": null,
+    \\"b\\": null,
+    \\"exampleNestedObject\\": {
+      \\"a\\": null,
+      \\"exampleArray\\": [\\"z\\", \\"b\\", \\"a\\"],
+      \\"examplePrimitive\\": 1,
+      \\"z\\": null
+    },
+    \\"z\\": null
+  },
+  2
+]
+"
+`;
+
+exports[`Sort JSON should sort an unsorted deeply nested JSON object recursively 1`] = `
+"{
+  \\"0\\": null,
+  \\"a\\": null,
+  \\"b\\": null,
+  \\"exampleNestedObject\\": {
+    \\"a\\": null,
+    \\"anotherObject\\": {
+      \\"exampleArray\\": [\\"z\\", \\"b\\", \\"a\\"],
+      \\"examplePrimitive\\": 1,
+      \\"yetAnother\\": {
+        \\"andAnother\\": {
+          \\"a\\": null,
+          \\"b\\": null,
+          \\"z\\": null
+        }
+      }
+    },
+    \\"z\\": null
+  },
+  \\"z\\": null
+}
+"
+`;
+
+exports[`Sort JSON should validate a deeply nested sorted JSON object recursively 1`] = `
+"{
+  \\"0\\": null,
+  \\"a\\": null,
+  \\"b\\": null,
+  \\"exampleNestedObject\\": {
+    \\"a\\": null,
+    \\"anotherObject\\": {
+      \\"exampleArray\\": [\\"z\\", \\"b\\", \\"a\\"],
+      \\"examplePrimitive\\": 1,
+      \\"yetAnother\\": {
+        \\"andAnother\\": {
+          \\"a\\": null,
+          \\"b\\": null,
+          \\"z\\": null
+        }
+      }
+    },
+    \\"z\\": null
   },
   \\"z\\": null
 }
@@ -56,7 +145,25 @@ exports[`Sort JSON should validate a sorted JSON object 1`] = `
   \\"b\\": null,
   \\"exampleNestedObject\\": {
     \\"z\\": null,
+    \\"exampleArray\\": [\\"z\\", \\"b\\", \\"a\\"],
+    \\"examplePrimitive\\": 1,
     \\"a\\": null
+  },
+  \\"z\\": null
+}
+"
+`;
+
+exports[`Sort JSON should validate a sorted JSON object recursively 1`] = `
+"{
+  \\"0\\": null,
+  \\"a\\": null,
+  \\"b\\": null,
+  \\"exampleNestedObject\\": {
+    \\"a\\": null,
+    \\"exampleArray\\": [\\"z\\", \\"b\\", \\"a\\"],
+    \\"examplePrimitive\\": 1,
+    \\"z\\": null
   },
   \\"z\\": null
 }
@@ -95,5 +202,26 @@ exports[`Sort JSON should validate a sorted JSON object with unconventional keys
   \\"{}\\": null,
   \\"￿\\": null
 }
+"
+`;
+
+exports[`Sort JSON should validate a sorted JSON object within an array recursively 1`] = `
+"[
+  1,
+  4,
+  {
+    \\"0\\": null,
+    \\"a\\": null,
+    \\"b\\": null,
+    \\"exampleNestedObject\\": {
+      \\"a\\": null,
+      \\"exampleArray\\": [\\"z\\", \\"b\\", \\"a\\"],
+      \\"examplePrimitive\\": 1,
+      \\"z\\": null
+    },
+    \\"z\\": null
+  },
+  2
+]
 "
 `;

--- a/index.test.ts
+++ b/index.test.ts
@@ -104,6 +104,8 @@ describe('Sort JSON', () => {
       b: null,
       exampleNestedObject: {
         z: null,
+        exampleArray: ['z', 'b', 'a'],
+        examplePrimitive: 1,
         a: null,
       },
       z: null,
@@ -127,6 +129,8 @@ describe('Sort JSON', () => {
       0: null,
       exampleNestedObject: {
         z: null,
+        exampleArray: ['z', 'b', 'a'],
+        examplePrimitive: 1,
         a: null,
       },
     };
@@ -136,6 +140,196 @@ describe('Sort JSON', () => {
       filepath: 'foo.json',
       parser: 'json',
       plugins: [SortJsonPlugin],
+    });
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should validate a sorted JSON object recursively', () => {
+    const fixture = {
+      0: null,
+      a: null,
+      b: null,
+      exampleNestedObject: {
+        a: null,
+        exampleArray: ['z', 'b', 'a'],
+        examplePrimitive: 1,
+        z: null,
+      },
+      z: null,
+    };
+
+    const input = JSON.stringify(fixture, null, 2);
+    const output = format(input, {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+      ...{
+        jsonRecursiveSort: true,
+      },
+    });
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should sort an unsorted JSON object recursively', () => {
+    const fixture = {
+      z: null,
+      a: null,
+      b: null,
+      0: null,
+      exampleNestedObject: {
+        z: null,
+        a: null,
+        exampleArray: ['z', 'b', 'a'],
+        examplePrimitive: 1,
+      },
+    };
+
+    const input = JSON.stringify(fixture, null, 2);
+    const output = format(input, {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+      ...{
+        jsonRecursiveSort: true,
+      },
+    });
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should validate a sorted JSON object within an array recursively', () => {
+    const fixture = [
+      1,
+      4,
+      {
+        0: null,
+        a: null,
+        b: null,
+        exampleNestedObject: {
+          a: null,
+          exampleArray: ['z', 'b', 'a'],
+          examplePrimitive: 1,
+          z: null,
+        },
+        z: null,
+      },
+      2,
+    ];
+
+    const input = JSON.stringify(fixture, null, 2);
+    const output = format(input, {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+      ...{
+        jsonRecursiveSort: true,
+      },
+    });
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should sort an unsorted JSON object within an array recursively', () => {
+    const fixture = [
+      1,
+      4,
+      {
+        z: null,
+        a: null,
+        b: null,
+        0: null,
+        exampleNestedObject: {
+          z: null,
+          a: null,
+          exampleArray: ['z', 'b', 'a'],
+          examplePrimitive: 1,
+        },
+      },
+      2,
+    ];
+
+    const input = JSON.stringify(fixture, null, 2);
+    const output = format(input, {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+      ...{
+        jsonRecursiveSort: true,
+      },
+    });
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should validate a deeply nested sorted JSON object recursively', () => {
+    const fixture = {
+      0: null,
+      a: null,
+      b: null,
+      exampleNestedObject: {
+        a: null,
+        anotherObject: {
+          exampleArray: ['z', 'b', 'a'],
+          examplePrimitive: 1,
+          yetAnother: {
+            andAnother: {
+              a: null,
+              b: null,
+              z: null,
+            },
+          },
+        },
+        z: null,
+      },
+      z: null,
+    };
+
+    const input = JSON.stringify(fixture, null, 2);
+    const output = format(input, {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+      ...{
+        jsonRecursiveSort: true,
+      },
+    });
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should sort an unsorted deeply nested JSON object recursively', () => {
+    const fixture = {
+      z: null,
+      a: null,
+      b: null,
+      0: null,
+      exampleNestedObject: {
+        z: null,
+        a: null,
+        anotherObject: {
+          yetAnother: {
+            andAnother: {
+              z: null,
+              b: null,
+              a: null,
+            },
+          },
+          exampleArray: ['z', 'b', 'a'],
+          examplePrimitive: 1,
+        },
+      },
+    };
+
+    const input = JSON.stringify(fixture, null, 2);
+    const output = format(input, {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+      ...{
+        jsonRecursiveSort: true,
+      },
     });
 
     expect(output).toMatchSnapshot();

--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,31 @@
 import { Parser } from 'prettier';
 import { parsers as babelParsers } from 'prettier/parser-babel';
 
+const isObject = (json: any) => json !== null && typeof json === 'object';
+
+function sortObject(object: any, recursive: boolean): any {
+  if (Array.isArray(object) && recursive) {
+    return object.map((entry: any) => {
+      return sortObject(entry, recursive);
+    });
+  } else if (object !== null && typeof object === 'object' && !Array.isArray(object)) {
+    const sortedJson: Record<string, any> = {};
+    for (const key of Object.keys(object).sort()) {
+      if (recursive && isObject(object[key])) {
+        sortedJson[key] = sortObject(object[key], recursive);
+      } else {
+        sortedJson[key] = object[key];
+      }
+    }
+    return sortedJson;
+  }
+  return object;
+}
+
 export const parsers = {
   'json': {
     ...babelParsers.json,
-    preprocess(text: any, options: any) {
+    preprocess(text, options: any) {
       let preprocessedText = text;
       /* istanbul ignore next */
       if (babelParsers.json.preprocess) {
@@ -19,17 +40,30 @@ export const parsers = {
         return text;
       }
 
+      const recursive = options.jsonRecursiveSort;
+
       // Only objects are intended to be sorted by this plugin
-      if (json === null || typeof json !== 'object' || Array.isArray(json)) {
+      if (json === null || typeof json !== 'object' || (Array.isArray(json) && !recursive)) {
         return text;
       }
 
-      const sortedJson: Record<string, any> = {};
-      for (const key of Object.keys(json).sort()) {
-        sortedJson[key] = json[key];
-      }
+      const sortedJson = sortObject(json, recursive);
 
       return JSON.stringify(sortedJson, null, 2);
     },
   },
 } as Record<string, Parser>;
+
+// I get a TypeScript error if I just set the type to 'boolean'
+// This fixes the error. I don't know why.
+const type: 'boolean' | 'path' | 'int' | 'choice' = 'boolean';
+
+export const options = {
+  jsonRecursiveSort: {
+    category: 'json-sort',
+    default: false,
+    description: 'Sort JSON files recursively, including any nested properties',
+    since: '0.0.2',
+    type,
+  },
+};


### PR DESCRIPTION
The `jsonRecursiveSort` option has been added. This enables recursive sorting of JSON objects within objects and arrays.

Closes #15