### PR TITLE
Lower minimum required `prettier` version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A plugin for [Prettier](https://prettier.io) that sorts JSON files by property n
 
 ## Requirements
 
-This module requires an [LTS](https://github.com/nodejs/Release) Node version (v10.0.0+), and `prettier` v2.0.0+.
+This module requires an [LTS](https://github.com/nodejs/Release) Node version (v10.0.0+), and `prettier` v2.1.0+.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "@types/prettier": "^2.2.0"
   },
   "peerDependencies": {
-    "prettier": "^2.2.1"
+    "prettier": "^2.1.0"
   }
 }


### PR DESCRIPTION
The minimum required `prettier` version required has been lowered to v6.1.0. v6.1.0 and later work correctly with this plugin, but prior versions don't support how the `jsonRecursiveSort` option is currently specified.

The README has been updated to reference this new minimum version as well.