### PR TITLE
Add a unit test to ensure objects within arrays are sorted.

### DIFF
--- a/__snapshots__/index.test.ts.snap
+++ b/__snapshots__/index.test.ts.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Sort JSON should sort JSON objects within an array 1`] = `
+"{
+  \\"0\\": null,
+  \\"a\\": null,
+  \\"b\\": null,
+  \\"exampleNestedObject\\": {
+    \\"a\\": null,
+    \\"exampleArray\\": [\\"z\\", \\"b\\", \\"a\\"],
+    \\"examplePrimitive\\": 1,
+    \\"z\\": null
+  },
+  \\"test\\": [
+    {
+      \\"baz\\": 3,
+      \\"foo\\": \\"bar\\"
+    },
+    {
+      \\"brz\\": 2,
+      \\"foo\\": \\"bag\\"
+    }
+  ],
+  \\"z\\": null
+}
+"
+`;
+
 exports[`Sort JSON should sort a JSON object with unconventional keys 1`] = `
 "{
   \\"\\": null,

--- a/__snapshots__/index.test.ts.snap
+++ b/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Sort JSON should sort JSON objects within an array 1`] = `
+exports[`Sort JSON should sort JSON objects recursively within a nested array 1`] = `
 "{
   \\"0\\": null,
   \\"a\\": null,
@@ -134,6 +134,32 @@ exports[`Sort JSON should sort an unsorted deeply nested JSON object recursively
     },
     \\"z\\": null
   },
+  \\"z\\": null
+}
+"
+`;
+
+exports[`Sort JSON should validate JSON objects recursively within a nested array 1`] = `
+"{
+  \\"0\\": null,
+  \\"a\\": null,
+  \\"b\\": null,
+  \\"exampleNestedObject\\": {
+    \\"a\\": null,
+    \\"exampleArray\\": [\\"z\\", \\"b\\", \\"a\\"],
+    \\"examplePrimitive\\": 1,
+    \\"z\\": null
+  },
+  \\"test\\": [
+    {
+      \\"baz\\": 3,
+      \\"foo\\": \\"bar\\"
+    },
+    {
+      \\"brz\\": 2,
+      \\"foo\\": \\"bag\\"
+    }
+  ],
   \\"z\\": null
 }
 "

--- a/index.test.ts
+++ b/index.test.ts
@@ -376,7 +376,7 @@ describe('Sort JSON', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should sort JSON objects within an array', () => {
+  it('should sort JSON objects recursively within a nested array', () => {
     const fixture = {
       test: [
         { foo: 'bar', baz: 3 },

--- a/index.test.ts
+++ b/index.test.ts
@@ -406,4 +406,35 @@ describe('Sort JSON', () => {
 
     expect(output).toMatchSnapshot();
   });
+
+  it('should validate JSON objects recursively within a nested array', () => {
+    const fixture = {
+      0: null,
+      a: null,
+      b: null,
+      exampleNestedObject: {
+        z: null,
+        a: null,
+        exampleArray: ['z', 'b', 'a'],
+        examplePrimitive: 1,
+      },
+      test: [
+        { baz: 3, foo: 'bar' },
+        { brz: 2, foo: 'bag' },
+      ],
+      z: null,
+    };
+
+    const input = JSON.stringify(fixture, null, 2);
+    const output = format(input, {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+      ...{
+        jsonRecursiveSort: true,
+      },
+    });
+
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/index.test.ts
+++ b/index.test.ts
@@ -375,4 +375,35 @@ describe('Sort JSON', () => {
 
     expect(output).toMatchSnapshot();
   });
+
+  it('should sort JSON objects within an array', () => {
+    const fixture = {
+      test: [
+        { foo: 'bar', baz: 3 },
+        { foo: 'bag', brz: 2 },
+      ],
+      z: null,
+      a: null,
+      b: null,
+      0: null,
+      exampleNestedObject: {
+        z: null,
+        a: null,
+        exampleArray: ['z', 'b', 'a'],
+        examplePrimitive: 1,
+      },
+    };
+
+    const input = JSON.stringify(fixture, null, 2);
+    const output = format(input, {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+      ...{
+        jsonRecursiveSort: true,
+      },
+    });
+
+    expect(output).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Before this pull request, there was no test to ensure that an object within an array had its keys sorted.