### PR TITLE
Add new option jsonObjectSortAlgorithm

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,9 +17,5 @@ module.exports = {
   }],
   rules: {
     'jest/no-restricted-matchers': 'off',
-    
-    'import/no-dynamic-require': 'off'
-    '@typescript-eslint/no-require-imports': 'off',
-    'nodejs/global-require': 'off'
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,9 @@ module.exports = {
   }],
   rules: {
     'jest/no-restricted-matchers': 'off',
+    
+    'import/no-dynamic-require': 'off'
+    '@typescript-eslint/no-require-imports': 'off',
+    'nodejs/global-require': 'off'
   },
 };

--- a/__snapshots__/index.test.ts.snap
+++ b/__snapshots__/index.test.ts.snap
@@ -1,5 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Sort JSON should sort a JSON object with a custom key sorting algorithm 1`] = `
+"{
+  \\"0\\": null,
+  \\"k\\": null,
+  \\"z\\": null,
+  \\"exampleNestedObject\\": {
+    \\"z\\": null,
+    \\"a\\": null,
+    \\"anotherObject\\": {
+      \\"yetAnother\\": {
+        \\"andAnother\\": {
+          \\"z\\": null,
+          \\"b\\": null,
+          \\"a\\": null
+        }
+      },
+      \\"exampleArray\\": [\\"z\\", \\"b\\", \\"a\\"],
+      \\"examplePrimitive\\": 1
+    }
+  },
+  \\"b\\": null,
+  \\"a\\": null
+}
+"
+`;
+
+exports[`Sort JSON should sort a JSON object with another custom key sorting algorithm 1`] = `
+"{
+  \\"f\\": null,
+  \\"o\\": null,
+  \\"u\\": null,
+  \\"b\\": null,
+  \\"a\\": null,
+  \\"r\\": null,
+  \\"exampleNestedObject\\": {
+    \\"z\\": null,
+    \\"a\\": null,
+    \\"anotherObject\\": {
+      \\"yetAnother\\": {
+        \\"andAnother\\": {
+          \\"z\\": null,
+          \\"b\\": null,
+          \\"a\\": null
+        }
+      },
+      \\"exampleArray\\": [\\"z\\", \\"b\\", \\"a\\"],
+      \\"examplePrimitive\\": 1
+    }
+  },
+  \\"k\\": null,
+  \\"z\\": null
+}
+"
+`;
+
 exports[`Sort JSON should sort a JSON object with unconventional keys 1`] = `
 "{
   \\"\\": null,

--- a/index.test.ts
+++ b/index.test.ts
@@ -375,4 +375,94 @@ describe('Sort JSON', () => {
 
     expect(output).toMatchSnapshot();
   });
+
+  it('should sort a JSON object with a custom key sorting algorithm', () => {
+    /**
+     * This example will place numbers first,
+     * then the string 'k', then sort the others in reverse chronological order.
+     * Known caveat: Due to a language quirk, the JSON will always display
+     * numeric values in ascending order before
+     * @see: https://www.stefanjudis.com/today-i-learned/property-order-is-predictable-in-javascript-objects-since-es2015/
+     */
+
+    const fixture = {
+      z: null,
+      a: null,
+      b: null,
+      k: null,
+      0: null,
+      exampleNestedObject: {
+        z: null,
+        a: null,
+        anotherObject: {
+          yetAnother: {
+            andAnother: {
+              z: null,
+              b: null,
+              a: null,
+            },
+          },
+          exampleArray: ['z', 'b', 'a'],
+          examplePrimitive: 1,
+        },
+      },
+    };
+
+    const input = JSON.stringify(fixture, null, 2);
+    const output = format(input, {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+      ...{
+        jsonObjectSortAlgorithm: './test/objectSortA.ts',
+      },
+    });
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should sort a JSON object with another custom key sorting algorithm', () => {
+    /**
+     * This example will place keys in the order:
+     * f o u b a r <rest in ascending order>
+     */
+
+    const fixture = {
+      f: null,
+      b: null,
+      u: null,
+      o: null,
+      r: null,
+      a: null,
+      k: null,
+      z: null,
+      exampleNestedObject: {
+        z: null,
+        a: null,
+        anotherObject: {
+          yetAnother: {
+            andAnother: {
+              z: null,
+              b: null,
+              a: null,
+            },
+          },
+          exampleArray: ['z', 'b', 'a'],
+          examplePrimitive: 1,
+        },
+      },
+    };
+
+    const input = JSON.stringify(fixture, null, 2);
+    const output = format(input, {
+      filepath: 'foo.json',
+      parser: 'json',
+      plugins: [SortJsonPlugin],
+      ...{
+        jsonObjectSortAlgorithm: './test/objectSortB.ts',
+      },
+    });
+
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/index.test.ts
+++ b/index.test.ts
@@ -377,6 +377,7 @@ describe('Sort JSON', () => {
   });
 
   it('should sort a JSON object with a custom key sorting algorithm', () => {
+
     /**
      * This example will place numbers first,
      * then the string 'k', then sort the others in reverse chronological order.
@@ -422,6 +423,7 @@ describe('Sort JSON', () => {
   });
 
   it('should sort a JSON object with another custom key sorting algorithm', () => {
+
     /**
      * This example will place keys in the order:
      * f o u b a r <rest in ascending order>

--- a/index.ts
+++ b/index.ts
@@ -1,18 +1,28 @@
 import { Parser, ParserOptions, SupportOptions } from 'prettier';
 import { parsers as babelParsers } from 'prettier/parser-babel';
 
+interface SortJsonOptions extends ParserOptions<any> {
+  jsonRecursiveSort?: boolean;
+  jsonObjectSortAlgorithm?: string;
+}
+
 const isObject = (json: any) => json !== null && typeof json === 'object';
 
-function sortObject(object: any, recursive: boolean): any {
+function sortObject(object: any, options: SortJsonOptions): any {
+  const { jsonRecursiveSort: recursive, jsonObjectSortAlgorithm: objectSortPath } = options;
+
   if (Array.isArray(object) && recursive) {
     return object.map((entry: any) => {
-      return sortObject(entry, recursive);
+      return sortObject(entry, options);
     });
-  } else if (object !== null && typeof object === 'object' && !Array.isArray(object)) {
+  } else if (isObject(object) && !Array.isArray(object)) {
+    const objectSortFunction: (a: string, b: string) => number
+      = objectSortPath ? require(objectSortPath).default : undefined;
+
     const sortedJson: Record<string, any> = {};
-    for (const key of Object.keys(object).sort()) {
+    for (const key of Object.keys(object).sort(objectSortFunction)) {
       if (recursive && isObject(object[key])) {
-        sortedJson[key] = sortObject(object[key], recursive);
+        sortedJson[key] = sortObject(object[key], options);
       } else {
         sortedJson[key] = object[key];
       }
@@ -40,14 +50,12 @@ export const parsers = {
         return text;
       }
 
-      const recursive = options.jsonRecursiveSort;
-
       // Only objects are intended to be sorted by this plugin
-      if (json === null || typeof json !== 'object' || (Array.isArray(json) && !recursive)) {
+      if (json === null || typeof json !== 'object' || (Array.isArray(json) && !options.jsonRecursiveSort)) {
         return text;
       }
 
-      const sortedJson = sortObject(json, recursive);
+      const sortedJson = sortObject(json, options);
 
       return JSON.stringify(sortedJson, null, 2);
     },
@@ -61,5 +69,12 @@ export const options: SupportOptions = {
     description: 'Sort all JSON data recursively, including any nested properties',
     since: '0.0.2',
     type: 'boolean',
+  },
+  jsonObjectSortAlgorithm: {
+    category: 'json-sort',
+    default: '',
+    description: 'Specify a file exporting a function to customize how object keys are sorted.',
+    since: '0.0.3',
+    type: 'path',
   },
 };

--- a/index.ts
+++ b/index.ts
@@ -16,8 +16,11 @@ function sortObject(object: any, options: SortJsonOptions): any {
       return sortObject(entry, options);
     });
   } else if (isObject(object) && !Array.isArray(object)) {
-    const objectSortFunction: (a: string, b: string) => number
-      = objectSortPath ? require(objectSortPath).default : undefined;
+    // ESLint does not like calling dynamic require().
+    /* eslint-disable import/no-dynamic-require, @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require */
+    const objectSortFunction: (a: string, b: string) => number =
+      objectSortPath ? require(objectSortPath).default : undefined;
+    /* eslint-enable import/no-dynamic-require, @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require */
 
     const sortedJson: Record<string, any> = {};
     for (const key of Object.keys(object).sort(objectSortFunction)) {

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { Parser } from 'prettier';
+import { Parser, ParserOptions, SupportOptions } from 'prettier';
 import { parsers as babelParsers } from 'prettier/parser-babel';
 
 const isObject = (json: any) => json !== null && typeof json === 'object';
@@ -25,7 +25,7 @@ function sortObject(object: any, recursive: boolean): any {
 export const parsers = {
   'json': {
     ...babelParsers.json,
-    preprocess(text, options: any) {
+    preprocess(text: string, options: SortJsonOptions) {
       let preprocessedText = text;
       /* istanbul ignore next */
       if (babelParsers.json.preprocess) {
@@ -54,16 +54,12 @@ export const parsers = {
   },
 } as Record<string, Parser>;
 
-// I get a TypeScript error if I just set the type to 'boolean'
-// This fixes the error. I don't know why.
-const type: 'boolean' | 'path' | 'int' | 'choice' = 'boolean';
-
-export const options = {
+export const options: SupportOptions = {
   jsonRecursiveSort: {
     category: 'json-sort',
     default: false,
-    description: 'Sort JSON files recursively, including any nested properties',
+    description: 'Sort all JSON data recursively, including any nested properties',
     since: '0.0.2',
-    type,
+    type: 'boolean',
   },
 };

--- a/test/objectSortA.ts
+++ b/test/objectSortA.ts
@@ -1,3 +1,6 @@
+// The following line prevents this file from being included in test coverage reports.
+/* istanbul ignore file */
+
 /**
  * This example will place numbers first,
  * then the string 'k', then sort the others in reverse chronological order.

--- a/test/objectSortA.ts
+++ b/test/objectSortA.ts
@@ -9,16 +9,24 @@
 /**
  * @param {string} a The first element to sort, converted to a string.
  * @param {string} b The second element to sort, converted to a string.
- * 
+ *
  * @returns {number} A number:
  * < 0 - First element must be placed before second
  *   0 - Both elements is equal, do not change order.
  * > 0 - Second element must be placed before first.
  */
-export default (a:string, b:string): number => {
-  if (a === b) return 0;
-  if (a === 'k') return -1000;
-  if (b === 'k') return 1000;
+const sort = (a: string, b: string): number => {
+  if (a === b) {
+    return 0;
+  }
+  if (a === 'k') {
+    return -1000;
+  }
+  if (b === 'k') {
+    return 1000;
+  }
 
   return b.localeCompare(a);
-}
+};
+
+export default sort;

--- a/test/objectSortA.ts
+++ b/test/objectSortA.ts
@@ -1,0 +1,24 @@
+/**
+ * This example will place numbers first,
+ * then the string 'k', then sort the others in reverse chronological order.
+ * Known caveat: Due to a language quirk, the JSON will always display
+ * numeric values in ascending order before
+ * @see: https://www.stefanjudis.com/today-i-learned/property-order-is-predictable-in-javascript-objects-since-es2015/
+ */
+
+/**
+ * @param {string} a The first element to sort, converted to a string.
+ * @param {string} b The second element to sort, converted to a string.
+ * 
+ * @returns {number} A number:
+ * < 0 - First element must be placed before second
+ *   0 - Both elements is equal, do not change order.
+ * > 0 - Second element must be placed before first.
+ */
+export default (a:string, b:string): number => {
+  if (a === b) return 0;
+  if (a === 'k') return -1000;
+  if (b === 'k') return 1000;
+
+  return b.localeCompare(a);
+}

--- a/test/objectSortB.ts
+++ b/test/objectSortB.ts
@@ -1,0 +1,33 @@
+/**
+ * This example will place specific keys in a specified order.
+ * Known caveat: Due to a language quirk, the JSON will always display
+ * numeric values in ascending order before
+ * @see: https://www.stefanjudis.com/today-i-learned/property-order-is-predictable-in-javascript-objects-since-es2015/
+ */
+
+/**
+ * @param {string} a The first element to sort, converted to a string.
+ * @param {string} b The second element to sort, converted to a string.
+ * 
+ * @returns {number} A number:
+ * < 0 - First element must be placed before second
+ *   0 - Both elements is equal, do not change order.
+ * > 0 - Second element must be placed before first.
+ */
+export default (a:string, b:string): number => {
+  const presort = ['f', 'o', 'u', 'b', 'a', 'r'];
+
+  if (!presort.includes(a) && !presort.includes(b)){
+    // Sort normally if not in presort.
+    return a.localeCompare(b);
+  } else if (presort.includes(a) && !presort.includes(b)) {
+    // Presort elements come first.
+    return -1000;
+  } else if (!presort.includes(a) && presort.includes(b)) {
+    // Presort elements come first.
+    return 1000;
+  } else {
+    // If a has a lower index, the result is negative, and a comes first.
+    return presort.indexOf(a) - presort.indexOf(b);
+  }
+}

--- a/test/objectSortB.ts
+++ b/test/objectSortB.ts
@@ -8,16 +8,16 @@
 /**
  * @param {string} a The first element to sort, converted to a string.
  * @param {string} b The second element to sort, converted to a string.
- * 
+ *
  * @returns {number} A number:
  * < 0 - First element must be placed before second
  *   0 - Both elements is equal, do not change order.
  * > 0 - Second element must be placed before first.
  */
-export default (a:string, b:string): number => {
+const sort = (a: string, b: string): number => {
   const presort = ['f', 'o', 'u', 'b', 'a', 'r'];
 
-  if (!presort.includes(a) && !presort.includes(b)){
+  if (!presort.includes(a) && !presort.includes(b)) {
     // Sort normally if not in presort.
     return a.localeCompare(b);
   } else if (presort.includes(a) && !presort.includes(b)) {
@@ -26,8 +26,9 @@ export default (a:string, b:string): number => {
   } else if (!presort.includes(a) && presort.includes(b)) {
     // Presort elements come first.
     return 1000;
-  } else {
-    // If a has a lower index, the result is negative, and a comes first.
-    return presort.indexOf(a) - presort.indexOf(b);
   }
-}
+  // If a has a lower index, the result is negative, and a comes first.
+  return presort.indexOf(a) - presort.indexOf(b);
+};
+
+export default sort;

--- a/test/objectSortB.ts
+++ b/test/objectSortB.ts
@@ -1,3 +1,6 @@
+// The following line prevents this file from being included in test coverage reports.
+/* istanbul ignore file */
+
 /**
  * This example will place specific keys in a specified order.
  * Known caveat: Due to a language quirk, the JSON will always display


### PR DESCRIPTION
With the new option `jsonObjectSortAlgorithm`, users can create a JavaScript file in their configuration, which exports a sort function, then specify the path of that file in their configuration.

That sort function will then be used by `Object.keys(object).sort()` to customize the order that the keys appear in.

This PR includes two test cases which demonstrate the usage of this new option. One exciting use case for this feature is demonstrated in the second test case; by defining an array and comparing indices, a pre-defined sort order can be used.

A note from issue #27, which this issue closes:

> In the rare circumstance that a user has an object with a key whose value is a number (such as `{ 0: true}`), those numbers will ALWAYS be displayed in ascending order and ALWAYS display before string keys.
> 
> [This key order is defined by JavaScript](https://www.stefanjudis.com/today-i-learned/property-order-is-predictable-in-javascript-objects-since-es2015/), and the only way to fix it would be to store the order of the keys during the sorting step, then override the `JSON.stringify` implementation to respect said order.
> 
> Since I did not want to perform a massive overhaul like this for a rare edge case, I have tried to document this caveat where relevant in the test cases.