### PR TITLE
Drop Node.js 10 support, and add Node.js 16 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
   },
   "peerDependencies": {
     "prettier": "^2.1.0"
+  },
+  "engines": {
+    "node": ">=12.0.0"
   }
 }


### PR DESCRIPTION
CI now tests with Node.js v12, v14, and v16. v16 was added to CI, and v10 was removed. Additionally, the `engines` field was  added to `package.json` to require v12 as the minimum Node.js version.

Fixes #38