### PR TITLE
Update Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,9 +10,11 @@ module.exports = {
       statements: 100,
     },
   },
-  moduleFileExtensions: ['ts', 'tsx', 'json', 'js', 'jsx', 'node'],
+  moduleFileExtensions: ['ts', 'js', 'json', 'jsx', 'tsx', 'node'],
   preset: 'ts-jest',
+  resetMocks: true,
+  restoreMocks: true,
   testEnvironment: 'node',
   testRegex: ['\\.test\\.ts$'],
-  testTimeout: 5000,
+  testTimeout: 2500,
 };


### PR DESCRIPTION
The options `restoreMocks` and `resetMocks` have been enabled to help prevent reusing mocks in unit tests. Also the test timeout was reduced, and the `moduleFileExtension` re-ordered in order of use.