### PR TITLE
Move ESLint ignore patterns into ESLint config file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,0 @@
-*.js
-!.eslintrc.js
-!jest.config.js
-node_modules
-dist
-coverage
-*.d.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,4 +14,5 @@ module.exports = {
       },
     },
   ],
+  ignorePatterns: ['!.eslintrc.js', '!.prettierrc.js', 'coverage', 'dist'],
 };


### PR DESCRIPTION
The ESLint ignore patterns are no longer in their own file. Also they've been adjusted somewhat to also lint JavaScript files, and to omit the unnecessary `node_modules` entry.