### PR TITLE
Update to Prettier v2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write"
   },
   "dependencies": {
-    "@types/prettier": "^2.2.0"
+    "@types/prettier": "^2.3.2"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^1.0.6",
@@ -51,7 +51,7 @@
     "typescript": "^4.1.5"
   },
   "peerDependencies": {
-    "prettier": "^2.1.0"
+    "prettier": "^2.3.2"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,10 +723,10 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.0.tgz#5f96562c1075ee715a5b138f0b7f591c1f40f6b8"
   integrity sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA==
 
-"@types/prettier@^2.2.0":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.1.tgz#374e31645d58cb18a07b3ecd8e9dede4deb2cccd"
-  integrity sha512-DxZZbyMAM9GWEzXL+BMZROWz9oo6A9EilwwOMET2UVu2uZTqMWS5S69KVtuVKaRjCUpcrOXRalet86/OpG4kqw==
+"@types/prettier@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
+  integrity sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
The `peerDependency` entry for `prettier` has been updated to v2.3, and the types used have been updated as well.