### PR TITLE
Add self-hosted Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,16 @@
+name: Renovate
+on:
+  schedule:
+    - cron: '0/15 * * * *'
+  workflow_dispatch:
+jobs:
+  renovate:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@7669f209b1c4c8fd9a6179f65d51cccffcd6a891
+        with:
+          configurationFile: renovate.json5
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,29 @@
+{
+  // Configuration
+  "branchPrefix": "renovate/",
+  "dependencyDashboard": true,
+  "github-actions": { "enabled": false },
+  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "ignoreScripts": true,
+  "internalChecksFilter": "strict",
+  "lockFileMaintenance": { "enabled": true },
+  "postUpdateOptions": ["yarnDedupeHighest"],
+  "postUpgradeTasks": {
+    "commands": ["yarn run allow-scripts auto"],
+    "fileFilters": ["package.json"],
+    "executionMode": "update"
+  },
+  "prConcurrentLimit": 10,
+  "rangeStrategy": "update-lockfile",
+  "repositories": ["Gudahtt/controllers-fork"],
+  "skipInstalls": false,
+  "stabilityDays": 30,
+  // Self-Hosted configuration
+  allowScripts: false,
+  allowedPostUpgradeCommands: ['yarn run allow-scripts auto'],
+  customEnvVariables: {
+    SKIP_ALLOW_SCRIPTS: 'true',
+  },
+  platform: 'github',
+  onboarding: false,
+}


### PR DESCRIPTION
A GitHub Action has been added to run Renovate every 15 minutes, or on demand via `workflow_dispatch`. It should only address security advisories and run lockfile maintenance for now.