### PR TITLE
Fix Renovate repository name

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -15,7 +15,7 @@
   },
   "prConcurrentLimit": 10,
   "rangeStrategy": "update-lockfile",
-  "repositories": ["Gudahtt/controllers-fork"],
+  "repositories": ["Gudahtt/prettier-plugin-sort-json"],
   "skipInstalls": false,
   "stabilityDays": 30,
   // Self-Hosted configuration


### PR DESCRIPTION
The repository name in the Renovate config was incorrect.