### PR TITLE
Renovate dependency grouping

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,29 +1,38 @@
 {
   // Configuration
-  "branchPrefix": "renovate/",
-  "dependencyDashboard": true,
-  "github-actions": { "enabled": false },
-  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
-  "ignoreScripts": true,
-  "internalChecksFilter": "strict",
-  "lockFileMaintenance": { "enabled": true },
-  "packageRules": [
+  branchPrefix: 'renovate/',
+  dependencyDashboard: true,
+  'github-actions': { enabled: false },
+  gitAuthor: 'Renovate Bot <bot@renovateapp.com>',
+  ignoreScripts: true,
+  internalChecksFilter: 'strict',
+  packageRules: [
     {
-      "matchPackagePatterns": ["^@metamask/eslint-config*"],
-      "groupName": "ESLint config"
-    }
+      excludePackageNames: ['typescript'],
+      groupName: 'Minor',
+      matchPackagePatterns: ['*'],
+      matchUpdateTypes: ['patch', 'minor'],
+    },
+    {
+      groupName: 'ESLint config',
+      matchPackagePatterns: ['^@metamask/eslint-config*'],
+    },
+    {
+      groupName: 'TypeScript',
+      matchPackageNames: ['typescript'],
+    },
   ],
-  "postUpdateOptions": ["yarnDedupeHighest"],
-  "postUpgradeTasks": {
-    "commands": ["yarn run allow-scripts auto"],
-    "fileFilters": ["package.json"],
-    "executionMode": "update"
+  postUpdateOptions: ['yarnDedupeHighest'],
+  postUpgradeTasks: {
+    commands: ['yarn run allow-scripts auto'],
+    fileFilters: ['package.json'],
+    executionMode: 'update',
   },
-  "prConcurrentLimit": 10,
-  "rangeStrategy": "update-lockfile",
-  "repositories": ["Gudahtt/prettier-plugin-sort-json"],
-  "skipInstalls": false,
-  "stabilityDays": 30,
+  prConcurrentLimit: 10,
+  rangeStrategy: 'update-lockfile',
+  repositories: ['Gudahtt/prettier-plugin-sort-json'],
+  skipInstalls: false,
+  stabilityDays: 30,
   // Self-Hosted configuration
   allowScripts: false,
   allowedPostUpgradeCommands: ['yarn run allow-scripts auto'],


### PR DESCRIPTION
Most dependency updates from Renovate are now grouped into one PR. Major updates will still have separate PRs, but minor and patch updates are grouped into a single PR.

TypeScript was extracted to its own group because minor version bumps are considered breaking for TypeScript, because it doesn't follow SemVer.

The Renovate config formatting has also been cleaned up.