### PR TITLE
Use minor version range for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier": "^2.3.2",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-jest": "^28.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "~4.7.4"
   },
   "peerDependencies": {
     "prettier": "^2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4699,7 +4699,7 @@ __metadata:
     prettier: ^2.3.2
     prettier-plugin-packagejson: ^2.2.11
     ts-jest: ^28.0.0
-    typescript: ^4.3.5
+    typescript: ~4.7.4
   peerDependencies:
     prettier: ^2.3.2
   languageName: unknown
@@ -5593,7 +5593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.3.5":
+"typescript@npm:~4.7.4":
   version: 4.7.4
   resolution: "typescript@npm:4.7.4"
   bin:
@@ -5603,7 +5603,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.3.5#~builtin<compat/typescript>":
+"typescript@patch:typescript@~4.7.4#~builtin<compat/typescript>":
   version: 4.7.4
   resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=7ad353"
   bin:


### PR DESCRIPTION
TypeScript does not follow SemVer, and uses minor releases for breaking changes. The supported TypeScript version range has been updated to recognize minor updates as breaking.