### PR TITLE
Improve install and configuration description

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Using `yarn`:
 yarn add --dev prettier-plugin-sort-json
 ```
 
+No configuration is necessary; Prettier will detect this plugin in your dependencies and use it automatically. There are some configuration options available ([described below](#configuration)), but they are all optional.
+
 ## Description
 
 This plugin adds a JSON preprocessor that will sort JSON files alphanumerically by key. By default, only top-level JSON objects are sorted. JSON files containing Arrays or other non-Object values are skipped.
@@ -27,6 +29,8 @@ This plugin adds a JSON preprocessor that will sort JSON files alphanumerically 
 Object entries are sorted by key lexically using [`Array.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort), according to each character's Unicode code point value.
 
 Note that this will not sort `package.json`, `package-lock.json`, or `composer.json`. This plugin only affects the `json` parser used by Prettier. Prettier uses an alternate parser (`json-stringify`) for those three specific files ([See here for details](https://github.com/prettier/prettier/blob/9a8b579d368db99394ab9da114cc37ba772fc887/src/language-js/index.js#L80)).
+
+This also will not sort JSON objects within other types of files, such as JavaScript or TypeScript files. This is just for sorting JSON files.
 
 ## Examples
 
@@ -62,11 +66,13 @@ After:
 
 ## Configuration
 
+These configuration options are all optional. Each option can be set as a CLI flag, or as an entry in your Prettier configuraton (e.g. in your `.prettierrc` file).
+
 ### JSON Recursive Sort
 
 Sort JSON objects recursively, including all nested objects.
 
-| Default | CLI Override            | API Override                |
+| Default | CLI                     | Configuration               |
 | ------- | ----------------------- | --------------------------- |
 | `false` | `--json-recursive-sort` | `jsonRecursiveSort: <bool>` |
 


### PR DESCRIPTION
The README has been updated to clarify that no configuration is necessary to use this plugin. It also now explains that this is for sorting JSON files, not JSON objects within other files.

Closes #55