### PR TITLE
Include symbols in sorting tests

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -64,6 +64,7 @@ exports[`Sort JSON should sort a JSON object with unconventional keys 1`] = `
 exports[`Sort JSON should sort an unsorted JSON object 1`] = `
 "{
   \\"0\\": null,
+  \\"$\\": null,
   \\"a\\": null,
   \\"b\\": null,
   \\"exampleNestedObject\\": {
@@ -193,6 +194,7 @@ exports[`Sort JSON should validate a deeply nested sorted JSON object recursivel
 exports[`Sort JSON should validate a sorted JSON object 1`] = `
 "{
   \\"0\\": null,
+  \\"$\\": null,
   \\"a\\": null,
   \\"b\\": null,
   \\"exampleNestedObject\\": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -100,6 +100,7 @@ describe('Sort JSON', () => {
   it('should validate a sorted JSON object', () => {
     const fixture = {
       0: null,
+      $: null,
       a: null,
       b: null,
       exampleNestedObject: {
@@ -125,6 +126,7 @@ describe('Sort JSON', () => {
     const fixture = {
       z: null,
       a: null,
+      $: null,
       b: null,
       0: null,
       exampleNestedObject: {


### PR DESCRIPTION
Symbols have been added to existing tests to capture the weird sorting of numbers ahead of everything else. This is because ES2015 specifies that integer indices are always sorted ahead of strings.