### PR TITLE
Rewrite plugin to sort AST

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/prettier": "^2.3.2"
   },
   "devDependencies": {
+    "@babel/types": "^7.18.10",
     "@lavamoat/allow-scripts": "^2.0.3",
     "@metamask/auto-changelog": "^2.6.1",
     "@metamask/eslint-config": "^9.0.0",

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -12,6 +12,7 @@ exports[`Sort JSON should sort JSON objects recursively within a nested array 1`
     \\"z\\": null
   },
   \\"test\\": [
+    null,
     {
       \\"baz\\": 3,
       \\"foo\\": \\"bar\\"
@@ -63,8 +64,8 @@ exports[`Sort JSON should sort a JSON object with unconventional keys 1`] = `
 
 exports[`Sort JSON should sort an unsorted JSON object 1`] = `
 "{
-  \\"0\\": null,
   \\"$\\": null,
+  \\"0\\": null,
   \\"a\\": null,
   \\"b\\": null,
   \\"exampleNestedObject\\": {
@@ -152,6 +153,7 @@ exports[`Sort JSON should validate JSON objects recursively within a nested arra
     \\"z\\": null
   },
   \\"test\\": [
+    null,
     {
       \\"baz\\": 3,
       \\"foo\\": \\"bar\\"
@@ -193,8 +195,8 @@ exports[`Sort JSON should validate a deeply nested sorted JSON object recursivel
 
 exports[`Sort JSON should validate a sorted JSON object 1`] = `
 "{
-  \\"0\\": null,
   \\"$\\": null,
+  \\"0\\": null,
   \\"a\\": null,
   \\"b\\": null,
   \\"exampleNestedObject\\": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -372,10 +372,7 @@ describe('Sort JSON', () => {
 
   it('should sort JSON objects recursively within a nested array', () => {
     const fixture = {
-      test: [
-        { foo: 'bar', baz: 3 },
-        { foo: 'bag', brz: 2 },
-      ],
+      test: [null, { foo: 'bar', baz: 3 }, { foo: 'bag', brz: 2 }],
       z: null,
       a: null,
       b: null,
@@ -412,10 +409,7 @@ describe('Sort JSON', () => {
         exampleArray: ['z', 'b', 'a'],
         examplePrimitive: 1,
       },
-      test: [
-        { baz: 3, foo: 'bar' },
-        { brz: 2, foo: 'bag' },
-      ],
+      test: [null, { baz: 3, foo: 'bar' }, { brz: 2, foo: 'bag' }],
       z: null,
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4700,6 +4700,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "prettier-plugin-sort-json@workspace:."
   dependencies:
+    "@babel/types": ^7.18.10
     "@lavamoat/allow-scripts": ^2.0.3
     "@metamask/auto-changelog": ^2.6.1
     "@metamask/eslint-config": ^9.0.0


### PR DESCRIPTION
The plugin now sorts JSON by sorting the AST, instead of using a preprocessor step.

This approach is more flexible because we aren't relying on `JSON.parse`, so we can handle invalid JSON. This approach also lets us override the sort order imposed by `JSON.stringify`, specifically that integers always come before string keys.