### PR TITLE
Fix `package.json` build file locations

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,9 @@
   },
   "license": "MIT",
   "author": "Mark Stacey <markjstacey@gmail.com>",
-  "main": "index.js",
+  "main": "dist/index.js",
   "files": [
-    "index.js",
-    "index.d.ts",
-    "index.js.map"
+    "dist"
   ],
   "scripts": {
     "build": "tsc --project .",


### PR DESCRIPTION
The build process was changed in #44 to use a `dist` directory, but I forgot to update `package.json`. It is now set to find the build files in the correct location, and include them in the package.