### PR TITLE
Add `types` field to manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "author": "Mark Stacey <markjstacey@gmail.com>",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
The `types` field has been added to the manifest so that this package works better with TypeScript dependant packages.