### PR TITLE
Update Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,6 +6,7 @@
   gitAuthor: 'Renovate Bot <bot@renovateapp.com>',
   ignoreScripts: true,
   internalChecksFilter: 'strict',
+  "enabledManagers": ["npm"],
   packageRules: [
     {
       excludePackageNames: ['typescript'],
@@ -21,6 +22,10 @@
       groupName: 'TypeScript',
       matchPackageNames: ['typescript'],
     },
+    {
+      groupName: 'Jest',
+      matchPackageNames: ['@types/jest', 'jest', 'ts-jest']
+    }
   ],
   postUpdateOptions: ['yarnDedupeHighest'],
   postUpgradeTasks: {


### PR DESCRIPTION
The Renovate config has been updated in two ways:
* All managers other than `npm` have been disabled.
  * Primarily this will stop Renovate from trying to update Node.js in `.nvmrc`. I never want Renovate to update that; I'd rather it always stay in-sync with the current minimum supported Node.js version (as specified in the `engines` field of `package.json`).
* Group Jest updates