### PR TITLE
Fix TypeScript configuration

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "inlineSources": true,
+    "noEmit": false,
     "outDir": "dist",
     "rootDir": "src",
     "sourceMap": true


### PR DESCRIPTION
The build configuration accidentally left `noEmit` enabled. It has been disabled.