### PR TITLE
Update minimum supported Node.js version to v16

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -24,7 +24,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -48,7 +48,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -78,7 +78,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A plugin for [Prettier](https://prettier.io) that sorts JSON files by property n
 
 ## Requirements
 
-This module requires an [LTS](https://github.com/nodejs/Release) Node version (v14.0.0+), and `prettier` v2.3.2+.
+This module requires an [LTS](https://github.com/nodejs/Release) Node version (v16.0.0+), and `prettier` v2.3.2+.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "packageManager": "yarn@3.6.1",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "lavamoat": {
     "allowScripts": {


### PR DESCRIPTION
v14 is no longer maintained, so v16 is now the minimum supported Node.js version.