### PR TITLE
Ignore lint errors in build output

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,13 @@ module.exports = {
       },
     },
   ],
-  ignorePatterns: ['!.eslintrc.js', '!.prettierrc.js', 'coverage', 'dist'],
+  ignorePatterns: [
+    '!.eslintrc.js',
+    '!.prettierrc.js',
+    'coverage',
+    'dist',
+    'build',
+  ],
 
   // This is required for rules that use type information.
   // See here for more information: https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/TYPED_LINTING.md


### PR DESCRIPTION
The migration from Jest to AVA in #163 introduced a second build directory (for test files), but we forgot to ignore it in the ESLint configuration.