### PR TITLE
Update to latest version of Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.0.0
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@7669f209b1c4c8fd9a6179f65d51cccffcd6a891
+        uses: renovatebot/github-action@89bd050bafa5a15de5d9383e3129edf210422004 # v40.1.5
         with:
           configurationFile: renovate.json5
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
The Renovate GitHub action has been updated to the latest version. I reviewed all breaking changes, for both the action and for Renovate itself, and none seem to require any changes for how it's used in this repository.