### PR TITLE
Migrate Renovate config to use newer syntax

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,7 @@
   ignoreScripts: true,
   internalChecksFilter: 'strict',
   "enabledManagers": ["npm"],
+  minimumReleaseAge: '30 days',
   packageRules: [
     {
       excludePackageNames: ['typescript'],
@@ -33,7 +34,6 @@
   rangeStrategy: 'update-lockfile',
   repositories: ['Gudahtt/prettier-plugin-sort-json'],
   skipInstalls: false,
-  stabilityDays: 30,
   // Self-Hosted configuration
   allowScripts: false,
   allowedPostUpgradeCommands: ['yarn run allow-scripts auto'],


### PR DESCRIPTION
The "stabilityDays" option was renamed to "minimumReleaseAge". I missed this whe reviewing the changelogs because it was a non-breaking change, the config gets migrated automatically when Renovate runs.

The config has been updated with the new configuration name so that no configuration migration is needed when Renovate is run.