### PR TITLE
Exclude Prettier from grouped Renovate update

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -10,7 +10,7 @@
   minimumReleaseAge: '30 days',
   packageRules: [
     {
-      excludePackageNames: ['typescript'],
+      excludePackageNames: ['prettier','typescript'],
       groupName: 'Minor',
       matchPackagePatterns: ['*'],
       matchUpdateTypes: ['patch', 'minor'],
@@ -18,6 +18,10 @@
     {
       groupName: 'ESLint config',
       matchPackagePatterns: ['^@metamask/eslint-config*'],
+    },
+        {
+      groupName: 'Prettier',
+      matchPackageNames: ['prettier'],
     },
     {
       groupName: 'TypeScript',


### PR DESCRIPTION
Prettier is now updated independenty of other packages by Renovate. This is because minor and patch updates can sometimes break the types used by this plugin.