### PR TITLE
Drop support for Node.js v16

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -24,7 +24,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -48,7 +48,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -78,7 +78,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Keys that do not match any defined category are treated as being in an implied l
 
 ### Setup
 
-- Install [Node.js](https://nodejs.org) version 16
+- Install the current LTS version of [Node.js](https://nodejs.org)
   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
 - Install [Yarn v3](https://yarnpkg.com/getting-started/install)
 - Run `yarn install` to install dependencies and run any requried post-install scripts

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "packageManager": "yarn@3.8.0",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "lavamoat": {
     "allowScripts": {


### PR DESCRIPTION
Support for Node.js v16 has been dropped. We no longer test v16 in CI, and the `engines` field has been updated to set v18 as the minimum supported version.

I've dropped support because Node.js v16 is no longer maintained, and because this bump was necessary in order to use newer versions of Yarn and AVA.

The README has been updated to suggest using the latest LTS for development rather than the minimum version.