### PR TITLE
Reduce Renovate frequency to once-per-hour

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,7 +1,7 @@
 name: Renovate
 on:
   schedule:
-    - cron: '0/15 * * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 jobs:
   renovate:


### PR DESCRIPTION
The Renovate bot now runs once per hour rather than once every 15 minutes. I found that whenever I'm actively working, I prefer to trigger runs myself, so the 15 minute frequency was getting in my way too often. Every hour is more than often enough.