### PR TITLE
Split Renovate project config from action config

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,5 +12,5 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@89bd050bafa5a15de5d9383e3129edf210422004 # v40.1.5
         with:
-          configurationFile: renovate.json5
+          configurationFile: renovate-action.json5
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate-action.json5
+++ b/renovate-action.json5
@@ -1,0 +1,10 @@
+{
+  allowScripts: false,
+  allowedPostUpgradeCommands: ['yarn run allow-scripts auto'],
+  customEnvVariables: {
+    SKIP_ALLOW_SCRIPTS: 'true',
+  },
+  onboarding: false,
+  platform: 'github',
+  repositories: ['Gudahtt/prettier-plugin-sort-json'],
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,5 +1,4 @@
 {
-  // Configuration
   branchPrefix: 'renovate/',
   dependencyDashboard: true,
   'github-actions': { enabled: false },
@@ -36,14 +35,5 @@
   },
   prConcurrentLimit: 10,
   rangeStrategy: 'update-lockfile',
-  repositories: ['Gudahtt/prettier-plugin-sort-json'],
   skipInstalls: false,
-  // Self-Hosted configuration
-  allowScripts: false,
-  allowedPostUpgradeCommands: ['yarn run allow-scripts auto'],
-  customEnvVariables: {
-    SKIP_ALLOW_SCRIPTS: 'true',
-  },
-  platform: 'github',
-  onboarding: false,
 }


### PR DESCRIPTION
The configuration for the Renovate action is now in the file `renovate-action.json5`, whereas project configuration remains in `renovate.json5`. Previously both were in the same file.