### PR TITLE
Reduce renovate frequency to once per day

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,7 +1,7 @@
 name: Renovate
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 jobs:
   renovate:


### PR DESCRIPTION
Renovate now runs once per day rather than once per hour. This is often enough; I find that I run it manually when I'm actively working on this repository.