### PR TITLE
chore: Simplify Renovate configuration

### DIFF
--- a/renovate-action.json5
+++ b/renovate-action.json5
@@ -1,9 +1,6 @@
 {
   allowScripts: false,
   allowedPostUpgradeCommands: ['yarn run allow-scripts auto'],
-  customEnvVariables: {
-    SKIP_ALLOW_SCRIPTS: 'true',
-  },
   onboarding: false,
   platform: 'github',
   repositories: ['Gudahtt/prettier-plugin-sort-json'],


### PR DESCRIPTION
Unnecessary custom environment variables have been removed from the Renovate self-hosted configuration.