### PR TITLE
chore: Cleanup renovate repository configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,11 +1,10 @@
 {
   branchPrefix: 'renovate/',
   dependencyDashboard: true,
-  'github-actions': { enabled: false },
+  enabledManagers: ['npm'],
   gitAuthor: 'Renovate Bot <bot@renovateapp.com>',
   ignoreScripts: true,
   internalChecksFilter: 'strict',
-  enabledManagers: ['npm'],
   minimumReleaseAge: '30 days',
   packageRules: [
     {
@@ -30,8 +29,8 @@
   postUpdateOptions: ['yarnDedupeHighest'],
   postUpgradeTasks: {
     commands: ['yarn run allow-scripts auto'],
-    fileFilters: ['package.json'],
     executionMode: 'update',
+    fileFilters: ['package.json'],
   },
   prConcurrentLimit: 10,
   rangeStrategy: 'update-lockfile',


### PR DESCRIPTION
One unnecessary option was removed, and some other entries were re- ordered to be in alphabetical order.

The removed option was `github-actions` (that manager isn not enabled)