### PR TITLE
chore: Set Renovate username

### DIFF
--- a/renovate-action.json5
+++ b/renovate-action.json5
@@ -4,5 +4,5 @@
   onboarding: false,
   platform: 'github',
   repositories: ['Gudahtt/prettier-plugin-sort-json'],
-  username: "renovate-bot",
+  username: 'renovate-bot',
 }


### PR DESCRIPTION
The docs suggest that this configuration property isn't needed or supported for the GitHub platform, but we'll see. This is a test.