### PR TITLE
Revert "chore: Set Renovate username"

### DIFF
--- a/renovate-action.json5
+++ b/renovate-action.json5
@@ -4,5 +4,4 @@
   onboarding: false,
   platform: 'github',
   repositories: ['Gudahtt/prettier-plugin-sort-json'],
-  username: 'renovate-bot',
 }


### PR DESCRIPTION
Reverts Gudahtt/prettier-plugin-sort-json#231

This change had no impact. There seems to be no way to customize the username Renovate uses when it's setup as a GitHub Action. It uses whatever account the PAT is generated from. Need to switch to using a bot account, or the GitHub App.