### PR TITLE
chore: Improve Renovate grouping

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,16 +14,29 @@
       matchUpdateTypes: ['patch', 'minor'],
     },
     {
-      groupName: 'ESLint config',
-      matchPackagePatterns: ['^@metamask/eslint-config*'],
+      groupName: 'ESLint related',
+      matchPackagePatterns: [
+        '^@metamask/eslint-config*',
+        'eslint',
+        'eslint-config-*',
+        'eslint-plugin-*',
+        'prettier',
+        'typescript',
+      ],
     },
+    // Prettier handled separately because plugin API is not stable
     {
       groupName: 'Prettier',
       matchPackageNames: ['prettier'],
+      matchUpdateTypes: ['patch', 'minor'],
     },
+    // TypeScript handled separately because it doesn't use SemVer
+    // The minor version is a peer dependency of the TypeScript ESLint
+    // configuration, so the minor bumps are left to that group.
     {
       groupName: 'TypeScript',
       matchPackageNames: ['typescript'],
+      matchUpdateTypes: ['patch'],
     },
   ],
   postUpdateOptions: ['yarnDedupeHighest'],


### PR DESCRIPTION
The ESLint-related packages that have peer dependencies on each other are now grouped together. These changes are meant to make it more likely that that group can be devoid of `peerDependency` warnings.