### PR TITLE
chore: Add missing entries from Renovate ESLint group

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,9 +19,11 @@
         '^@metamask/eslint-config*',
         'eslint',
         'eslint-config-*',
+        'eslint-import-resolver-typescript',
         'eslint-plugin-*',
         'prettier',
         'typescript',
+        'typescript-eslint',
       ],
     },
     // Prettier handled separately because plugin API is not stable


### PR DESCRIPTION
These two entries are also ESLint-related dependencies that are linked via `peerDependencies`.