### PR TITLE
docs: Clarify non-object exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ After:
 
 - Non-objects
 
-  This is meant to sort objects. JSON files containing Arrays or other non-Object values are skipped.
+  This is meant to sort objects. JSON files with a top-level value that is not an object are skipped.
 
 - JSON files with dedicated Prettier parsers
 


### PR DESCRIPTION
The README section on skipping non-objects has been updated to clarify that it's talking about the top-level value of a file specifically.