### PR TITLE
chore: Add test coverage

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,6 @@
+{
+  "100": true,
+  "all": true,
+  "reporter": ["html", "text"],
+  "src": "./src"
+}

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -87,7 +87,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - run: yarn --immutable --immutable-cache
-      - run: yarn test
+      - run: yarn test:coverage
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# Jest
+# Test coverage
 coverage
 
 # ESLint

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.json5' '**/*.md' '**/*.yml' '!.yarnrc.yml' '!fixtures/invalid-json.json' --ignore-path .gitignore",
     "prepack": "./scripts/prepack.sh",
-    "test": "tsc --project tsconfig.test.json && ava"
+    "test": "tsc --project tsconfig.test.json && ava",
+    "test:coverage": "tsc --project tsconfig.test.json && c8 --config ./.c8rc.json ava"
   },
   "devDependencies": {
     "@ava/typescript": "^5.0.0",
@@ -35,6 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "ava": "^6.0.0",
+    "c8": "^10.1.2",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-import-resolver-typescript": "^3.6.3",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -114,8 +114,8 @@ test('should throw if jsonRecursiveSort is not a boolean', async (t) => {
         },
       }),
     {
-      // `.+` used to match color codes
-      message: /^Invalid .+jsonRecursiveSort.+ value./u,
+      // `(?:.+)?` used to match color codes
+      message: /^Invalid (?:.+)?jsonRecursiveSort(?:.+)? value./u,
     },
   );
 });
@@ -132,8 +132,8 @@ test('should throw if custom sort is not a string', async (t) => {
         },
       }),
     {
-      // `.+` used to match color codes
-      message: /^Invalid .+jsonSortOrder.+ value./u,
+      // `(?:.+)?` used to match color codes
+      message: /^Invalid (?:.+)?jsonSortOrder(?:.+)? value./u,
     },
   );
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -102,6 +102,42 @@ test('should throw Syntax Error in parser for invalid JSON', async (t) => {
   );
 });
 
+test('should throw if jsonRecursiveSort is not a boolean', async (t) => {
+  await t.throwsAsync(
+    async () =>
+      format('{}', {
+        filepath: 'foo.json',
+        parser: 'json',
+        plugins: [SortJsonPlugin],
+        ...{
+          jsonRecursiveSort: 'yes',
+        },
+      }),
+    {
+      // `.+` used to match color codes
+      message: /^Invalid .+jsonRecursiveSort.+ value./u,
+    },
+  );
+});
+
+test('should throw if custom sort is not a string', async (t) => {
+  await t.throwsAsync(
+    async () =>
+      format('{}', {
+        filepath: 'foo.json',
+        parser: 'json',
+        plugins: [SortJsonPlugin],
+        ...{
+          jsonSortOrder: 10,
+        },
+      }),
+    {
+      // `.+` used to match color codes
+      message: /^Invalid .+jsonSortOrder.+ value./u,
+    },
+  );
+});
+
 test('should throw if custom sort is invalid JSON', async (t) => {
   await t.throwsAsync(
     async () =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,9 +157,11 @@ function assertObjectPropertyTypes(
   const invalidProperty = properties.find(
     (property) => property.type !== 'ObjectProperty',
   );
+  /* c8 ignore start */
   if (invalidProperty !== undefined) {
     throw new Error(`Property type not supported: ${invalidProperty.type}`);
   }
+  /* c8 ignore stop */
 }
 
 /**
@@ -172,11 +174,13 @@ function assertObjectPropertyTypes(
 function assertObjectPropertyKeyType(
   objectPropertyKey: ObjectProperty['key'],
 ): asserts objectPropertyKey is StringLiteral {
+  /* c8 ignore start */
   if (objectPropertyKey.type !== 'StringLiteral') {
     throw new Error(
       `Object property key type not supported: ${objectPropertyKey.type}`,
     );
   }
+  /* c8 ignore stop */
 }
 
 /**
@@ -209,9 +213,10 @@ function sortAst(
       (element: null | NullLiteral | Expression | SpreadElement) => {
         if (element === null || element.type === 'NullLiteral') {
           return element;
-        } else if (element.type === 'SpreadElement') {
+        } /* c8 ignore start */ else if (element.type === 'SpreadElement') {
           throw new Error('Unreachable; SpreadElement is not allowed in JSON');
         }
+        /* c8 ignore stop */
         return sortAst(element, recursive, sortCompareFunction);
       },
     );
@@ -259,20 +264,26 @@ type SortJsonOptions = {
  * @returns JSON sort options.
  */
 function parseOptions(prettierOptions: ParserOptions): SortJsonOptions {
-  const jsonRecursiveSort = prettierOptions.jsonRecursiveSort ?? false;
+  const { jsonRecursiveSort } = prettierOptions;
 
+  // Unreachable, validated before here by Prettier
+  /* c8 ignore start */
   if (typeof jsonRecursiveSort !== 'boolean') {
     throw new Error(
       `Invalid 'jsonRecursiveSort' option; expected boolean, got '${typeof prettierOptions.jsonRecursiveSort}'`,
     );
   }
+  /* c8 ignore stop */
 
   const rawJsonSortOrder = prettierOptions.jsonSortOrder ?? null;
+  // Unreachable, validated before here by Prettier
+  /* c8 ignore start */
   if (rawJsonSortOrder !== null && typeof rawJsonSortOrder !== 'string') {
     throw new Error(
       `Invalid 'jsonSortOrder' option; expected string, got '${typeof prettierOptions.rawJsonSortOrder}'`,
     );
   }
+  /* c8 ignore stop */
 
   let jsonSortOrder = null;
   if (rawJsonSortOrder !== null) {
@@ -320,10 +331,12 @@ function createSortCompareFunction(
     const regexResult = entry.match(regexRegex);
     if (regexResult) {
       const [, regexSpec, flags]: string[] = regexResult;
+      /* c8 ignore start */
       if (!regexSpec) {
         // The RegExp specifies that this capture group be non-empty, so this is unreachable
         throw new Error('Unreachable, empty RegExp specification found');
       }
+      /* c8 ignore stop */
       const regex = new RegExp(regexSpec, flags);
       return Boolean(value.match(regex));
     }
@@ -344,15 +357,19 @@ function createSortCompareFunction(
       return 1;
     } else if (aIndex === bIndex) {
       const sortEntry = sortEntries[aIndex];
+      /* c8 ignore start */
       if (sortEntry === undefined) {
         // Sort entry guaranteed to be non-null because index was found
         throw new Error('Unreachable, undefined sort entry');
       }
+      /* c8 ignore stop */
       const categorySort = jsonSortOrder[sortEntry];
+      /* c8 ignore start */
       if (categorySort === undefined) {
         // Guaranteed to be defined because `sortEntry` is derived from `Object.keys`
         throw new Error('Unreachable, undefined category sort entry');
       }
+      /* c8 ignore stop */
       const categorySortFunction =
         categorySort === null
           ? lexicalSort

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "inlineSources": true,
     "noEmit": false,
-    "outDir": "build"
+    "outDir": "build",
+    "sourceMap": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bcoe/v8-coverage@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@bcoe/v8-coverage@npm:0.2.3"
+  checksum: 10c0/6b80ae4cb3db53f486da2dc63b6e190a74c8c3cca16bb2733f234a0b6a9382b09b146488ae08e2b22cf00f6c83e20f3e040a2f7894f05c045c946d6a090b1d52
+  languageName: node
+  linkType: hard
+
 "@es-joy/jsdoccomment@npm:~0.49.0":
   version: 0.49.0
   resolution: "@es-joy/jsdoccomment@npm:0.49.0"
@@ -175,6 +182,37 @@ __metadata:
     wrap-ansi: "npm:^8.1.0"
     wrap-ansi-cjs: "npm:wrap-ansi@^7.0.0"
   checksum: 10c0/b1bf42535d49f11dc137f18d5e4e63a28c5569de438a221c369483731e9dac9fb797af554e8bf02b6192d1e5eba6e6402cf93900c3d0ac86391d00d04876789e
+  languageName: node
+  linkType: hard
+
+"@istanbuljs/schema@npm:^0.1.2, @istanbuljs/schema@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@istanbuljs/schema@npm:0.1.3"
+  checksum: 10c0/61c5286771676c9ca3eb2bd8a7310a9c063fb6e0e9712225c8471c582d157392c88f5353581c8c9adbe0dff98892317d2fdfc56c3499aa42e0194405206a963a
+  languageName: node
+  linkType: hard
+
+"@jridgewell/resolve-uri@npm:^3.1.0":
+  version: 3.1.2
+  resolution: "@jridgewell/resolve-uri@npm:3.1.2"
+  checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:^1.4.14":
+  version: 1.5.0
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
+  checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.12":
+  version: 0.3.25
+  resolution: "@jridgewell/trace-mapping@npm:0.3.25"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.1.0"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
+  checksum: 10c0/3d1ce6ebc69df9682a5a8896b414c6537e428a1d68b02fcc8363b04284a8ca0df04d0ee3013132252ab14f2527bc13bea6526a912ecb5658f0e39fd2860b4df4
   languageName: node
   linkType: hard
 
@@ -455,6 +493,13 @@ __metadata:
   version: 1.0.6
   resolution: "@types/estree@npm:1.0.6"
   checksum: 10c0/cdfd751f6f9065442cd40957c07fd80361c962869aa853c1c2fd03e101af8b9389d8ff4955a43a6fcfa223dd387a089937f95be0f3eec21ca527039fd2d9859a
+  languageName: node
+  linkType: hard
+
+"@types/istanbul-lib-coverage@npm:^2.0.1":
+  version: 2.0.6
+  resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
+  checksum: 10c0/3948088654f3eeb45363f1db158354fb013b362dba2a5c2c18c559484d5eb9f6fd85b23d66c0a7c2fcfab7308d0a585b14dadaca6cc8bf89ebfdc7f8f5102fb7
   languageName: node
   linkType: hard
 
@@ -923,6 +968,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"c8@npm:^10.1.2":
+  version: 10.1.2
+  resolution: "c8@npm:10.1.2"
+  dependencies:
+    "@bcoe/v8-coverage": "npm:^0.2.3"
+    "@istanbuljs/schema": "npm:^0.1.3"
+    find-up: "npm:^5.0.0"
+    foreground-child: "npm:^3.1.1"
+    istanbul-lib-coverage: "npm:^3.2.0"
+    istanbul-lib-report: "npm:^3.0.1"
+    istanbul-reports: "npm:^3.1.6"
+    test-exclude: "npm:^7.0.1"
+    v8-to-istanbul: "npm:^9.0.0"
+    yargs: "npm:^17.7.2"
+    yargs-parser: "npm:^21.1.1"
+  peerDependencies:
+    monocart-coverage-reports: ^2
+  peerDependenciesMeta:
+    monocart-coverage-reports:
+      optional: true
+  bin:
+    c8: bin/c8.js
+  checksum: 10c0/882903f22c08f9053b7b274ba31c374cf141d027c46cda57e6472798f82437c5d73fe25bd25b60d6b01c9de383615ae932e6c4d7d4acd7ea231216215f207217
+  languageName: node
+  linkType: hard
+
 "cacache@npm:^18.0.0":
   version: 18.0.3
   resolution: "cacache@npm:18.0.3"
@@ -1121,6 +1192,13 @@ __metadata:
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
   checksum: 10c0/7ab51d30b52d461412cd467721bb82afe695da78fff8f29fe6f6b9cbaac9a2328e27a22a966014df9532100f6dd85370460be8130b9c677891ba36d96a343f50
+  languageName: node
+  linkType: hard
+
+"convert-source-map@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "convert-source-map@npm:2.0.0"
+  checksum: 10c0/8f2f7a27a1a011cc6cc88cc4da2d7d0cfa5ee0369508baae3d98c260bb3ac520691464e5bbe4ae7cdf09860c1d69ecc6f70c63c6e7c7f7e3f18ec08484dc7d9b
   languageName: node
   linkType: hard
 
@@ -1822,6 +1900,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"foreground-child@npm:^3.1.1":
+  version: 3.3.0
+  resolution: "foreground-child@npm:3.3.0"
+  dependencies:
+    cross-spawn: "npm:^7.0.0"
+    signal-exit: "npm:^4.0.1"
+  checksum: 10c0/028f1d41000553fcfa6c4bb5c372963bf3d9bf0b1f25a87d1a6253014343fb69dfb1b42d9625d7cf44c8ba429940f3d0ff718b62105d4d4a4f6ef8ca0a53faa2
+  languageName: node
+  linkType: hard
+
 "fs-minipass@npm:^2.0.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
@@ -1956,6 +2044,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^10.4.1":
+  version: 10.4.5
+  resolution: "glob@npm:10.4.5"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^3.1.2"
+    minimatch: "npm:^9.0.4"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^1.11.1"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/19a9759ea77b8e3ca0a43c2f07ecddc2ad46216b786bb8f993c445aee80d345925a21e5280c7b7c6c59e860a0154b84e4b2b60321fea92cd3c56b4a7489f160e
+  languageName: node
+  linkType: hard
+
 "glob@npm:^7.1.3":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -2041,6 +2145,13 @@ __metadata:
   dependencies:
     lru-cache: "npm:^10.0.1"
   checksum: 10c0/b19dbd92d3c0b4b0f1513cf79b0fc189f54d6af2129eeb201de2e9baaa711f1936929c848b866d9c8667a0f956f34bf4f07418c12be1ee9ca74fd9246335ca1f
+  languageName: node
+  linkType: hard
+
+"html-escaper@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: 10c0/208e8a12de1a6569edbb14544f4567e6ce8ecc30b9394fcaa4e7bb1e60c12a7c9a1ed27e31290817157e8626f3a4f29e76c8747030822eb84a6abb15c255f0a0
   languageName: node
   linkType: hard
 
@@ -2301,6 +2412,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
+  version: 3.2.2
+  resolution: "istanbul-lib-coverage@npm:3.2.2"
+  checksum: 10c0/6c7ff2106769e5f592ded1fb418f9f73b4411fd5a084387a5410538332b6567cd1763ff6b6cadca9b9eb2c443cce2f7ea7d7f1b8d315f9ce58539793b1e0922b
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-report@npm:^3.0.0, istanbul-lib-report@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "istanbul-lib-report@npm:3.0.1"
+  dependencies:
+    istanbul-lib-coverage: "npm:^3.0.0"
+    make-dir: "npm:^4.0.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10c0/84323afb14392de8b6a5714bd7e9af845cfbd56cfe71ed276cda2f5f1201aea673c7111901227ee33e68e4364e288d73861eb2ed48f6679d1e69a43b6d9b3ba7
+  languageName: node
+  linkType: hard
+
+"istanbul-reports@npm:^3.1.6":
+  version: 3.1.7
+  resolution: "istanbul-reports@npm:3.1.7"
+  dependencies:
+    html-escaper: "npm:^2.0.0"
+    istanbul-lib-report: "npm:^3.0.0"
+  checksum: 10c0/a379fadf9cf8dc5dfe25568115721d4a7eb82fbd50b005a6672aff9c6989b20cc9312d7865814e0859cd8df58cbf664482e1d3604be0afde1f7fc3ccc1394a51
+  languageName: node
+  linkType: hard
+
 "jackspeak@npm:^3.1.2":
   version: 3.4.1
   resolution: "jackspeak@npm:3.4.1"
@@ -2448,6 +2587,15 @@ __metadata:
   dependencies:
     semver: "npm:^6.0.0"
   checksum: 10c0/56aaafefc49c2dfef02c5c95f9b196c4eb6988040cf2c712185c7fe5c99b4091591a7fc4d4eafaaefa70ff763a26f6ab8c3ff60b9e75ea19876f49b18667ecaa
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "make-dir@npm:4.0.0"
+  dependencies:
+    semver: "npm:^7.5.3"
+  checksum: 10c0/69b98a6c0b8e5c4fe9acb61608a9fbcfca1756d910f51e5dbe7a9e5cfb74fca9b8a0c8a0ffdf1294a740826c1ab4871d5bf3f62f72a3049e5eac6541ddffed68
   languageName: node
   linkType: hard
 
@@ -3077,6 +3225,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8.0.0"
     "@typescript-eslint/parser": "npm:^8.0.0"
     ava: "npm:^6.0.0"
+    c8: "npm:^10.1.2"
     eslint: "npm:^9.0.0"
     eslint-config-prettier: "npm:^9.0.0"
     eslint-import-resolver-typescript: "npm:^3.6.3"
@@ -3657,6 +3806,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"test-exclude@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "test-exclude@npm:7.0.1"
+  dependencies:
+    "@istanbuljs/schema": "npm:^0.1.2"
+    glob: "npm:^10.4.1"
+    minimatch: "npm:^9.0.4"
+  checksum: 10c0/6d67b9af4336a2e12b26a68c83308c7863534c65f27ed4ff7068a56f5a58f7ac703e8fc80f698a19bb154fd8f705cdf7ec347d9512b2c522c737269507e7b263
+  languageName: node
+  linkType: hard
+
 "time-zone@npm:^1.0.0":
   version: 1.0.0
   resolution: "time-zone@npm:1.0.0"
@@ -3803,6 +3963,17 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
+  languageName: node
+  linkType: hard
+
+"v8-to-istanbul@npm:^9.0.0":
+  version: 9.3.0
+  resolution: "v8-to-istanbul@npm:9.3.0"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.12"
+    "@types/istanbul-lib-coverage": "npm:^2.0.1"
+    convert-source-map: "npm:^2.0.0"
+  checksum: 10c0/968bcf1c7c88c04df1ffb463c179558a2ec17aa49e49376120504958239d9e9dad5281aa05f2a78542b8557f2be0b0b4c325710262f3b838b40d703d5ed30c23
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add test coverage using `c8`. Coverage reports are available locally in `coverage` after running `yarn test:coverage`. Required coverage is set to 100%, with all unreachable code skipped with comments.