### PR TITLE
fix: Fix `jsonSortOrder` validation

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -96,6 +96,20 @@ for (const parser of supportedParsers) {
     t.is(output, '');
   });
 
+  test(`${parser}: ignores undefined options`, async (t) => {
+    const output = await format('{}\n', {
+      filepath: `foo.${fileExtensions[parser]}`,
+      parser,
+      plugins: [SortJsonPlugin],
+      ...{
+        jsonRecursiveSort: undefined,
+        jsonSortOrder: undefined,
+      },
+    });
+
+    t.is(output, '{}\n');
+  });
+
   test(`${parser}: throws Syntax Error in parser for invalid JSON`, async (t) => {
     await t.throwsAsync(
       async () =>
@@ -124,19 +138,6 @@ for (const parser of supportedParsers) {
         message: /^Invalid (?:.+)?jsonRecursiveSort(?:.+)? value./u,
       },
     );
-  });
-
-  test(`${parser}: ignores undefined jsonSortOrder`, async (t) => {
-    const output = await format('\n', {
-      filepath: `foo.${fileExtensions[parser]}`,
-      parser,
-      plugins: [SortJsonPlugin],
-      ...{
-        jsonSortOrder: undefined,
-      },
-    });
-
-    t.is(output, '');
   });
 
   test(`${parser}: throws if custom sort is not a string`, async (t) => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -126,6 +126,19 @@ for (const parser of supportedParsers) {
     );
   });
 
+  test(`${parser}: ignores undefined jsonSortOrder`, async (t) => {
+    const output = await format('\n', {
+      filepath: `foo.${fileExtensions[parser]}`,
+      parser,
+      plugins: [SortJsonPlugin],
+      ...{
+        jsonSortOrder: undefined,
+      },
+    });
+
+    t.is(output, '');
+  });
+
   test(`${parser}: throws if custom sort is not a string`, async (t) => {
     await t.throwsAsync(
       async () =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,10 @@ function parseOptions(
     jsonRecursiveSort: prettierOptions.jsonRecursiveSort,
   };
 
-  if ('jsonSortOrder' in prettierOptions) {
+  if (
+    'jsonSortOrder' in prettierOptions &&
+    prettierOptions.jsonSortOrder !== undefined
+  ) {
     const rawJsonSortOrder = prettierOptions.jsonSortOrder;
     // Unreachable, validated before here by Prettier
     /* c8 ignore start */

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,10 +284,7 @@ function parseOptions(
     jsonRecursiveSort: prettierOptions.jsonRecursiveSort,
   };
 
-  if (
-    'jsonSortOrder' in prettierOptions &&
-    prettierOptions.jsonSortOrder !== undefined
-  ) {
+  if (prettierOptions.jsonSortOrder !== undefined) {
     const rawJsonSortOrder = prettierOptions.jsonSortOrder;
     // Unreachable, validated before here by Prettier
     /* c8 ignore start */


### PR DESCRIPTION
The validation assumed that the option would be omitted from `prettierOptions` if it was not set. However it appears that Prettier sets it to `undefined` rather than omitting it altogether.

The validation has been updated to treat `undefined` as equivalent to the option being omitted.

Fixes #262