### PR TITLE
docs: add `pnpm` installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Using `npm`:
 npm install --save-dev prettier-plugin-sort-json
 ```
 
+Using `pnpm`:
+
+```console
+pnpm add --save-dev prettier-plugin-sort-json
+```
+
 Using `yarn`:
 
 ```console


### PR DESCRIPTION
Add the `pnpm` installation option in addition to `npm` and `yarn` alternatives.