### PR TITLE
fix: ignoring files json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ You could do that with this `.prettierrc.json` file:
 {
   "overrides": [
     {
-      "excludedFiles": ["./json/unsorted.json"],
+      "excludeFiles": ["./json/unsorted.json"],
       "files": ["./json/**"],
       "options": {
         "plugins": ["prettier-plugin-sort-json"]


### PR DESCRIPTION
It fixs _ignoring files json_ example. `excludedFiles` was incorrect, it must be `excludeFiles` (without `d`).