### PR TITLE
Fix broken README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Here is an example `.prettierrc` file with all default options set:
 {
   "plugins": ["prettier-plugin-sort-json"],
   "jsonRecursiveSort": false,
-  "jsonSortOrder": "{\"*\": \"lexical\"}"
+  "jsonSortOrder": "{\"/.*/\": \"lexical\"}"
 }
 ```
 


### PR DESCRIPTION
The example default configuration in the README was incorrect. It used a `*` key instead of `/.*/`, which likely was at fault for confusing some of the people in #275

The example has been fixed.