### PR TITLE
Add JavaScript example of default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,27 @@ There are some additional configuration options available ([described below](#co
 
 These configuration options are all optional. Each option can be set as a CLI flag, or as an entry in your Prettier configuraton (e.g. in your `.prettierrc` file).
 
-Here is an example `.prettierrc` file with all default options set:
+Here are example Prettier configuration files with all default options set:
 
-```json
-{
-  "plugins": ["prettier-plugin-sort-json"],
-  "jsonRecursiveSort": false,
-  "jsonSortOrder": "{\"/.*/\": \"lexical\"}"
-}
-```
+- `.prettierrc.json`:
+
+  ```json
+  {
+    "plugins": ["prettier-plugin-sort-json"],
+    "jsonRecursiveSort": false,
+    "jsonSortOrder": "{\"/.*/\": \"lexical\"}"
+  }
+  ```
+
+- `.prettierrc.js`:
+
+  ```javascript
+  module.exports = {
+    plugins: ['prettier-plugin-sort-json'],
+    jsonRecursiveSort: false,
+    jsonSortOrder: JSON.stringify({ [/.*/]: 'lexical' }),
+  };
+  ```
 
 ### JSON Recursive Sort
 


### PR DESCRIPTION
This is easier to read, and increases visbility of the suggested `JSON.stringify` + RegExp literal strategy of writing the config.