### PR TITLE
Add npm link metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "https://github.com/Gudahtt/prettier-plugin-sort-json.git"
   },
+  "homepage": "https://github.com/Gudahtt/prettier-plugin-sort-json#readme",
+  "bugs": {
+    "url": "https://github.com/Gudahtt/prettier-plugin-sort-json/issues"
+  },
   "license": "MIT",
   "author": "Mark Stacey <markjstacey@gmail.com>",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata for the README
- add npm `bugs.url` metadata for the public issue tracker

The published package currently exposes repository metadata, but does not expose homepage or bugs links in npm package metadata.

## Verification
- `node -e "const p=require('./package.json'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,homepage:p.homepage,bugs:p.bugs},null,2)); if(p.name!=='prettier-plugin-sort-json'||p.homepage!=='https://github.com/Gudahtt/prettier-plugin-sort-json#readme'||p.bugs?.url!=='https://github.com/Gudahtt/prettier-plugin-sort-json/issues') process.exit(1)"`
- `git diff --check`