### PR TITLE
ci: fix Renovate config match patterns

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -10,7 +10,7 @@
     {
       groupName: 'Minor',
       matchUpdateTypes: ['patch', 'minor'],
-      matchPackageNames: ['!prettier', '!typescript', '*'],
+      matchPackageNames: ['!prettier', '!typescript'],
     },
     {
       groupName: 'ESLint related',


### PR DESCRIPTION
A recent Renovate update uncovered a pre-existing misconfiguration with the match patterns used by the "Minor" group. Apparently the '*' entry overrides the negative matches, and it should be omitted for the negative matches to work.

Fixes #336