### PR TITLE
ci: use Renovate for GitHub Actions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,7 @@
 {
   branchPrefix: 'renovate/',
   dependencyDashboard: true,
-  enabledManagers: ['npm'],
+  enabledManagers: ['github-actions', 'npm'],
   gitAuthor: 'Renovate Bot <bot@renovateapp.com>',
   ignoreScripts: true,
   internalChecksFilter: 'strict',
@@ -11,6 +11,7 @@
       groupName: 'Minor',
       matchUpdateTypes: ['patch', 'minor'],
       matchPackageNames: ['!prettier', '!typescript'],
+      matchCategories: ['npm'],
     },
     {
       groupName: 'ESLint related',
@@ -23,12 +24,14 @@
         '/prettier/',
         '/typescript-eslint/',
       ],
+      matchCategories: ['npm'],
     },
     // Prettier handled separately because plugin API is not stable
     {
       groupName: 'Prettier',
       matchPackageNames: ['prettier'],
       matchUpdateTypes: ['patch', 'minor'],
+      matchCategories: ['npm'],
     },
     // TypeScript handled separately because it doesn't use SemVer
     // The minor version is a peer dependency of the TypeScript ESLint
@@ -37,6 +40,7 @@
       groupName: 'TypeScript',
       matchPackageNames: ['typescript'],
       matchUpdateTypes: ['patch'],
+      matchCategories: ['npm'],
     },
   ],
   postUpdateOptions: ['yarnDedupeHighest'],


### PR DESCRIPTION
We'll try with just the defaults for now.