### PR TITLE
ci: silence expected github-actions lookup warnings

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -42,6 +42,12 @@
       matchUpdateTypes: ['patch'],
       matchCategories: ['npm'],
     },
+    // Ignore MetaMask actions, Renovate will not be able to find updates for them
+    {
+      matchPackageNames: ['MetaMask/*'],
+      matchCategories: ['github-actions'],
+      enabled: false,
+    },
   ],
   postUpdateOptions: ['yarnDedupeHighest'],
   postUpgradeTasks: {


### PR DESCRIPTION
The `MetaMask` actions are not tracked by Renovate, so the lookups will always fail.