### PR TITLE
Revert "ci: silence expected github-actions lookup warnings"

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -42,12 +42,6 @@
       matchUpdateTypes: ['patch'],
       matchCategories: ['npm'],
     },
-    // Ignore MetaMask actions, Renovate will not be able to find updates for them
-    {
-      matchPackageNames: ['MetaMask/*'],
-      matchCategories: ['github-actions'],
-      enabled: false,
-    },
   ],
   postUpdateOptions: ['yarnDedupeHighest'],
   postUpgradeTasks: {


### PR DESCRIPTION
Reverts Gudahtt/prettier-plugin-sort-json#346 for two reasons:
* It didn't work
* The motivation for it was incorrect; these lookups _should_ work because it's just checking public repo tags. Failure is not expected. There must be an auth error, I'll investigate later.