### PR TITLE
ci: add Renovate log level variable

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,3 +14,5 @@ jobs:
         with:
           configurationFile: renovate-action.json5
           token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ env.RENOVATE_LOG_LEVEL }}


### PR DESCRIPTION
This will let me set the log level of the Renovate job by updating a repository variable.