### PR TITLE
ci: fix Renovate log level variable

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,4 +15,4 @@ jobs:
           configurationFile: renovate-action.json5
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
-          LOG_LEVEL: ${{ env.RENOVATE_LOG_LEVEL }}
+          LOG_LEVEL: ${{ vars.RENOVATE_LOG_LEVEL }}


### PR DESCRIPTION
The `RENOVATE_LOG_LEVEL` variable was accidentally referenced via `env` instead of `vars`. I was misled by `actionlint` showing an error when I tried accessing `vars`. It turns out this was a bug, and `actionlint` has now been updated with a fix.