### PR TITLE
ci: customize Renovate git author

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
   branchPrefix: 'renovate/',
   dependencyDashboard: true,
   enabledManagers: ['github-actions', 'npm'],
-  gitAuthor: 'Renovate Bot <bot@renovateapp.com>',
+  gitAuthor: 'GudahttBot <gudahttbot@users.noreply.github.com>',
   ignoreScripts: true,
   internalChecksFilter: 'strict',
   minimumReleaseAge: '30 days',


### PR DESCRIPTION
Renovate prints a warning to the console every run to explain that this should be customized.