### PR TITLE
ci: set Renovate gitAuthor earlier

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,3 +16,4 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           LOG_LEVEL: ${{ vars.RENOVATE_LOG_LEVEL }}
+          RENOVATE_GIT_AUTHOR: "GudahttBot (Renovate) <gudahttbot+renovate@users.noreply.github.com>"

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,6 @@
   branchPrefix: 'renovate/',
   dependencyDashboard: true,
   enabledManagers: ['github-actions', 'npm'],
-  gitAuthor: 'GudahttBot <gudahttbot@users.noreply.github.com>',
   ignoreScripts: true,
   internalChecksFilter: 'strict',
   minimumReleaseAge: '30 days',


### PR DESCRIPTION
The warning about `gitAuthor` not being set was still appearing in the Renovate logs because it was set in the repository config, and that config isn't read until after the first time the warning is printed.

The git author has been moved to an environment variable instead, where it will be available sooner.

The git author has also been updated to make it more specific to renovate. The Renovate docs warn that the author is expected to be used only by Renovate, and it will force-push over commits from that same author without regard for what is being overwritten. It was safer to update the email, in case I end up using the GudahttBot account for other commits.